### PR TITLE
exploration: potential improvement to fitter settings

### DIFF
--- a/ao486.qsf
+++ b/ao486.qsf
@@ -30,7 +30,7 @@ set_global_assignment -name FINAL_PLACEMENT_OPTIMIZATION ALWAYS
 set_global_assignment -name FITTER_EFFORT "STANDARD FIT"
 set_global_assignment -name OPTIMIZATION_MODE "AGGRESSIVE PERFORMANCE"
 set_global_assignment -name ALLOW_POWER_UP_DONT_CARE ON
-set_global_assignment -name QII_AUTO_PACKED_REGISTERS NORMAL
+set_global_assignment -name QII_AUTO_PACKED_REGISTERS "SPARSE AUTO"
 set_global_assignment -name ROUTER_LCELL_INSERTION_AND_LOGIC_DUPLICATION ON
 set_global_assignment -name PHYSICAL_SYNTHESIS_COMBO_LOGIC ON
 set_global_assignment -name PHYSICAL_SYNTHESIS_REGISTER_DUPLICATION ON
@@ -66,3 +66,5 @@ source sys/sys.tcl
 source sys/sys_analog.tcl
 source files.qip
 set_instance_assignment -name PARTITION_HIERARCHY root_partition -to | -section_id Top
+set_global_assignment -name PLACEMENT_EFFORT_MULTIPLIER 8.0
+set_global_assignment -name PHYSICAL_SYNTHESIS_EFFORT EXTRA


### PR DESCRIPTION
Current fitter settings were not putting enough effort by Quartus into timing performance or the fit. 8.0x effort multiplier and physical synthesis effort settings increase the effort to fit, initial default seed "1" yielded a successful compile for the first time I've ever seen. QII_AUTO_PACKED_REGISTERS, according to the tooltip says "SPARSE AUTO" to be the best effort at timing performance, and this core needs every bit of timing performance.

I am currently running a 100 seed run in DSE to find out what the best seed is for this build in terms of timing and fmax. When that is completed in a few days I will update this PR with that seed so it can be compiled, along with the test results as documentation in a reply.

I have been testing these improved fitter settings for a few weeks with multiple Design Space Explorer runs on multiple cores and they seem to yield better results.