### PR TITLE
Fix overlapping CS for IDE and Floppy

### DIFF
--- a/rtl/system.v
+++ b/rtl/system.v
@@ -302,10 +302,10 @@ ao486 ao486
 );
 
 always @(posedge clk_sys) begin
-	ide0_cs       <= ({iobus_address[15:3], 3'd0} == 16'h01F0) || ({iobus_address[15:1], 1'd0} == 16'h03F6);
-	ide1_cs       <= ({iobus_address[15:3], 3'd0} == 16'h0170) || ({iobus_address[15:1], 1'd0} == 16'h0376);
+	ide0_cs       <= ({iobus_address[15:3], 3'd0} == 16'h01F0) || ({iobus_address[15:0]} == 16'h03F6);
+	ide1_cs       <= ({iobus_address[15:3], 3'd0} == 16'h0170) || ({iobus_address[15:0]} == 16'h0376);
 	joy_cs        <= ({iobus_address[15:0]      } == 16'h0201);
-	floppy0_cs    <= ({iobus_address[15:3], 3'd0} == 16'h03F0);
+	floppy0_cs    <= ({iobus_address[15:2], 2'd0} == 16'h03F0) || ({iobus_address[15:1], 1'd0} == 16'h03F4) || ({iobus_address[15:0]} == 16'h03F7) ;
 	dma_master_cs <= ({iobus_address[15:5], 5'd0} == 16'h00C0);
 	dma_page_cs   <= ({iobus_address[15:4], 4'd0} == 16'h0080);
 	dma_slave_cs  <= ({iobus_address[15:4], 4'd0} == 16'h0000);


### PR DESCRIPTION
This is a partial fix for #103 and allows reading of floppy disks under Windows NT.

I have found that the CS signals for ide0 and floppy0 were overlapping, and this was blocking the system from properly accessing the floppy controller's "Digital Input Register" (at 0x3F7) where the "disk changed" flag is read from. This flag is not used by DOS or Windows 95, but is used by NT and Linux. I have updated the mappings of the CS signals to match that expected by the  original hardware.

**Old I/O mappings:** 
IDE0: 0x1F0-0x1F7 and 0x3F6-0x3F**7**
IDE1: 0x170-0x177 and 0x376-0x377
Floppy: 0x3F0-0x3F**7**

**New I/O mappings:**
IDE0: 0x1F0-0x1F7 and 0x3F6
IDE1: 0x170-0x177 and 0x376
Floppy: 0x3F0-0x3F5 and 0x3F7

Note that further work is needed around reset_changeline in floppy.v, as the flag is still not being set high by an image change (image ejection seems to be fine though). This is why this is only a partial fix for #103.