### PR TITLE
Add support for mounting IMA and VFD floppy image files

### DIFF
--- a/ao486.sv
+++ b/ao486.sv
@@ -197,8 +197,8 @@ led fdd_led(clk_sys, |mgmt_req[7:6], LED_USER);
 localparam CONF_STR =
 {
 	"AO486;UART115200:4000000(Turbo 115200),MIDI;",
-	"S0,IMG,Floppy A:;",
-	"S1,IMG,Floppy B:;",
+	"S0,IMGIMAVFD,Floppy A:;",
+	"S1,IMGIMAVFD,Floppy B:;",
 	"O12,Write Protect,None,A:,B:,A: & B:;",
 	"-;",
 	"S2,VHD,IDE 0-0;",


### PR DESCRIPTION
They have the same file structure as IMG images. I tested with images created with WinImage to be sure this worked. It also works to just rename the images, but might as well support more image types.