### PR TITLE
sound: Updated the DSP write port status busy flag

### DIFF
--- a/rtl/soc/sound/sound.v
+++ b/rtl/soc/sound/sound.v
@@ -98,6 +98,8 @@ sound_dsp sound_dsp_inst
 
 	.clock_rate      (clk_rate),
 
+	.ce_1us          (ce_1us),
+
 	.irq8            (irq8),
 	.irq16           (irq16),
 


### PR DESCRIPTION
Previously the write port status busy flag was set on any DMA
request, and then cleared when the software polled for the
status. This caused problems with software using auto-init DMA
because the busy flag may be reset by the new transfer before
it polled a second time resulting in the DSP always returning
busy.

The logic was updated to instead use a fixed busy timer that
clears independently from the software polling for status.

Fixes MiSTer-devel/ao486_MiSTer#117