### PR TITLE
Fix Doom OPL3 detection, timing improvements

### DIFF
--- a/rtl/soc/sound/opl3/host_if.sv
+++ b/rtl/soc/sound/opl3/host_if.sv
@@ -53,7 +53,7 @@ module host_if
     input wire wr_n,
     input wire [1:0] address,
     input wire [REG_FILE_DATA_WIDTH-1:0] din,
-    output logic [REG_FILE_DATA_WIDTH-1:0] dout,
+    output logic [REG_FILE_DATA_WIDTH-1:0] dout = 0,
     output opl3_reg_wr_t opl3_reg_wr = 0,
     input wire [REG_FILE_DATA_WIDTH-1:0] status,
     output logic force_timer_overflow
@@ -121,7 +121,9 @@ module host_if
     );
 
     // Doom DMXOPTION=-opl3-phase detection routine specifically reads address 'b10 to see if it's all ones
-    always_comb dout = address == 0 ? host_status : '1;
+    // Decompiled routine provided by Never_Again at https://www.vogons.org/viewtopic.php?f=7&t=100285
+    always_ff @(posedge clk_host)
+        dout <= address_p1 == 0 ? host_status : '1;
 
     generate
     if (INSTANTIATE_TIMERS)

--- a/rtl/soc/sound/opl3/host_if.sv
+++ b/rtl/soc/sound/opl3/host_if.sv
@@ -62,6 +62,7 @@ module host_if
     logic [1:0] opl3_address;
     logic [REG_FILE_DATA_WIDTH-1:0] opl3_data;
     logic wr;
+    logic [REG_FILE_DATA_WIDTH-1:0] host_status;
 
     always_comb wr = !cs_n && !wr_n;
 
@@ -104,8 +105,11 @@ module host_if
     ) dout_sync (
         .clk(clk_host),
         .in(status),
-        .out(dout)
+        .out(host_status)
     );
+
+    // Doom DMXOPTION=-opl3-phase specifically reads address 0+2 to see if it's all ones
+    always_comb dout = address == 0 ? host_status : '1;
 
     generate
     if (INSTANTIATE_TIMERS)

--- a/rtl/soc/sound/opl3/trick_sw_detection.sv
+++ b/rtl/soc/sound/opl3/trick_sw_detection.sv
@@ -27,6 +27,9 @@
 #        else
 #            $error("OPL3 not detected...");
 #
+#   Think Volkswagon cheating on the diesel emmisions test by detecting they're under test, except this is to
+#   accomplish good. This works for Doom OPL detection under ao486MiSTer.
+#
 #   CHANGE HISTORY:
 #   12 April 2024    Greg Taylor
 #       Initial version
@@ -76,26 +79,23 @@ module trick_sw_detection
     input wire [REG_FILE_DATA_WIDTH-1:0] din,
     output logic force_timer_overflow
 );
-    localparam NUM_READS_TO_TRIGGER_OVERFLOW = 20;
+    localparam NUM_READS_TO_TRIGGER_OVERFLOW = 50;
 
     logic wr;
-    logic wr_p1 = 0;
     logic [$clog2(NUM_READS_TO_TRIGGER_OVERFLOW)-1:0] host_rd_counter = 0;
     opl3_reg_wr_t host_reg_wr;
     logic rd;
     logic rd_p1 = 0;
     logic host_force_timer_overflow = 0;
     logic start_counter = 0;
+    logic [REG_TIMER_WIDTH-1:0] timer1 = 0;
 
     always_comb wr = !cs_n && !wr_n;
-
-    always_ff @(posedge clk_host)
-        wr_p1 <= wr;
 
     always_ff @(posedge clk_host) begin
         host_reg_wr.valid <= 0;
 
-        if (wr && !wr_p1)
+        if (wr)
             if (!address[0]) begin // address write mode
                 host_reg_wr.bank_num <= address[1];
                 host_reg_wr.address <= din;
@@ -105,8 +105,13 @@ module trick_sw_detection
                 host_reg_wr.data <= din;
             end
 
-        if (!ic_n)
+        if (host_reg_wr.valid && host_reg_wr.bank_num == 0 && host_reg_wr.address == 'h2)
+            timer1 <= host_reg_wr.data;
+
+        if (!ic_n) begin
             host_reg_wr <= 0;
+            timer1 <= 0;
+        end
     end
 
     always_comb rd = !cs_n && !rd_n;
@@ -114,7 +119,7 @@ module trick_sw_detection
     always_ff @(posedge clk_host) begin
         rd_p1 <= rd;
 
-        if (host_reg_wr.valid && host_reg_wr.bank_num == 0 && host_reg_wr.address == 'h4 && host_reg_wr.data[0]) begin
+        if (host_reg_wr.valid && host_reg_wr.bank_num == 0 && host_reg_wr.address == 'h4 && host_reg_wr.data[0] && timer1 == 'hff) begin
             start_counter <= 1;
             host_rd_counter <= 0;
             host_force_timer_overflow <= 0;

--- a/rtl/soc/sound/sound.v
+++ b/rtl/soc/sound/sound.v
@@ -78,7 +78,7 @@ module sound
 wire sb_read  = read  & sb_cs;
 wire sb_write = write & sb_cs;
 
-always @(posedge clk) readdata <= mixer_rd ? mixer_val : cms_rd ? data_from_cms : (!address[2:0]) ? (opl_dout | (fm_mode ? 8'h00 : 8'h06)) : data_from_dsp;
+always @(posedge clk) readdata <= mixer_rd ? mixer_val : cms_rd ? data_from_cms : opl_cs ? (opl_dout | (fm_mode ? 8'h00 : 8'h06)) : data_from_dsp;
 
 //------------------------------------------------------------------------------
 
@@ -155,7 +155,7 @@ wire opl_cs = (           address[2:1] == 0 && sb_cs)  //220-221,228-229
            || (fm_mode &&   address[1] == 1 && fm_cs); //38A-38B
 
 wire opl_wr = write && !cms_wr;
-wire opl_rd = read && (address == 8);
+wire opl_rd = read;
 
 opl3 opl
 (


### PR DESCRIPTION
Decompiled Doom OPL3 detection routine for `DMXOPTION=-opl3-phase` provided by Never_Again at https://www.vogons.org/viewtopic.php?f=7&t=100285. This env var now gets picked up by Doom and we finally have stereo!

The timing improvements came with some nice area reductions.

Made normal adlib detection routine slightly more robust as well.