### PR TITLE
Fix waveform #6, reset envelope on all operators

### DIFF
--- a/rtl/soc/sound/opl3/channels.sv
+++ b/rtl/soc/sound/opl3/channels.sv
@@ -46,6 +46,7 @@ module channels
     import opl3_pkg::*;
 (
     input wire clk,
+    input wire reset,
     input wire clk_dac,
     input var opl3_reg_wr_t opl3_reg_wr,
     input wire sample_clk_en,

--- a/rtl/soc/sound/opl3/control_operators.sv
+++ b/rtl/soc/sound/opl3/control_operators.sv
@@ -49,6 +49,7 @@ module control_operators
     import opl3_pkg::*;
 (
     input wire clk,
+    input wire reset,
     input wire sample_clk_en,
     input var opl3_reg_wr_t opl3_reg_wr,
     input wire [REG_CONNECTION_SEL_WIDTH-1:0] connection_sel,

--- a/rtl/soc/sound/opl3/envelope_generator.sv
+++ b/rtl/soc/sound/opl3/envelope_generator.sv
@@ -48,6 +48,7 @@ module envelope_generator
     parameter SILENCE = 511
 )(
     input wire clk,
+    input wire reset,
     input wire sample_clk_en,
     input wire [BANK_NUM_WIDTH-1:0] bank_num,
     input wire [OP_NUM_WIDTH-1:0] op_num,
@@ -134,7 +135,8 @@ module envelope_generator
         .*
     );
 
-    mem_multi_bank #(
+    // on reset all operators will go into RELEASE state
+    mem_multi_bank_reset #(
         .DATA_WIDTH($bits(state_t)),
         .DEPTH(NUM_OPERATORS_PER_BANK),
         .OUTPUT_DELAY(0),
@@ -142,6 +144,8 @@ module envelope_generator
         .NUM_BANKS(NUM_BANKS)
     ) state_mem (
         .clk,
+        .reset('0),
+        .reset_mem(reset),
         .wea(sample_clk_en_p[1]),
         .reb(sample_clk_en),
         .banka(bank_num_p[1]),
@@ -149,7 +153,8 @@ module envelope_generator
         .bankb(bank_num),
         .addrb(op_num),
         .dia({state_p1}),
-        .dob({state_p0})
+        .dob({state_p0}),
+        .reset_mem_done_pulse()
     );
 
     always_ff @(posedge clk)

--- a/rtl/soc/sound/opl3/host_if.sv
+++ b/rtl/soc/sound/opl3/host_if.sv
@@ -66,6 +66,7 @@ module host_if
     logic [1:0] opl3_address;
     logic [REG_FILE_DATA_WIDTH-1:0] opl3_data;
     logic wr_p1;
+    logic wr_p2 = 0;
     logic [REG_FILE_DATA_WIDTH-1:0] host_status;
 
     // relax timing on clk_host
@@ -74,6 +75,7 @@ module host_if
         wr_p1_n <= wr_n;
         address_p1 <= address;
         din_p1 <= din;
+        wr_p2 <= wr_p1;
     end
 
     always_comb wr_p1 = !cs_p1_n && !wr_p1_n;
@@ -84,7 +86,7 @@ module host_if
     ) afifo (
 		.i_wclk(clk_host),
 		.i_wr_reset_n(ic_n),
-		.i_wr(wr_p1),
+		.i_wr(wr_p1 && !wr_p2),
 		.i_wr_data({address_p1, din_p1}),
 		.o_wr_full(),
 		.i_rclk(clk),

--- a/rtl/soc/sound/opl3/mem_multi_bank_reset.sv
+++ b/rtl/soc/sound/opl3/mem_multi_bank_reset.sv
@@ -1,0 +1,166 @@
+/*******************************************************************************
+#   +html+<pre>
+#
+#   FILENAME: mem_multi_bank_reset.sv
+#   AUTHOR: Greg Taylor     CREATION DATE: 16 May 2024
+#
+#   DESCRIPTION:
+#
+#   CHANGE HISTORY:
+#   16 May 2024    Greg Taylor
+#       Initial version
+#
+#   Copyright (C) 2014 Greg Taylor <gtaylor@sonic.net>
+#
+#   This file is part of OPL3 FPGA.
+#
+#   OPL3 FPGA is free software: you can redistribute it and/or modify
+#   it under the terms of the GNU Lesser General Public License as published by
+#   the Free Software Foundation, either version 3 of the License, or
+#   (at your option) any later version.
+#
+#   OPL3 FPGA is distributed in the hope that it will be useful,
+#   but WITHOUT ANY WARRANTY; without even the implied warranty of
+#   MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+#   GNU Lesser General Public License for more details.
+#
+#   You should have received a copy of the GNU Lesser General Public License
+#   along with OPL3 FPGA.  If not, see <http://www.gnu.org/licenses/>.
+#
+#   Original Java Code:
+#   Copyright (C) 2008 Robson Cozendey <robson@cozendey.com>
+#
+#   Original C++ Code:
+#   Copyright (C) 2012  Steffen Ohrendorf <steffen.ohrendorf@gmx.de>
+#
+#   Some code based on forum posts in:
+#   http://forums.submarine.org.uk/phpBB/viewforum.php?f=9,
+#   Copyright (C) 2010-2013 by carbon14 and opl3
+#
+#******************************************************************************/
+`timescale 1ns / 1ps
+`default_nettype none
+/* altera message_off 10230 */
+
+module mem_multi_bank_reset #(
+    parameter DATA_WIDTH = 0,
+    parameter DEPTH = 0,
+    parameter OUTPUT_DELAY = 0, // 0, 1, or 2
+    parameter DEFAULT_VALUE = '0,
+    parameter NUM_BANKS = 0,
+    parameter BANK_WIDTH = $clog2(NUM_BANKS)
+) (
+    input wire clk,
+    input wire reset,
+    input wire reset_mem,
+    input wire wea,
+    input wire reb, // only used if OUTPUT_DELAY >0
+    input wire [BANK_WIDTH-1:0] banka,
+    input wire [$clog2(DEPTH)-1:0] addra,
+    input wire [BANK_WIDTH-1:0] bankb,
+    input wire [$clog2(DEPTH)-1:0] addrb,
+    input wire [DATA_WIDTH-1:0] dia,
+    output logic [DATA_WIDTH-1:0] dob,
+    output logic reset_mem_done_pulse
+);
+    localparam PIPELINE_DELAY = 2;
+
+    logic [NUM_BANKS-1:0] wea_array;
+    logic [NUM_BANKS-1:0] reb_array;
+    logic [DATA_WIDTH-1:0] dob_array [NUM_BANKS];
+    logic [PIPELINE_DELAY:1] [BANK_WIDTH-1:0] bankb_p;
+
+    enum {
+        IDLE,
+        RESETTING
+    } state = IDLE, next_state;
+
+    struct packed {
+        logic [BANK_WIDTH-1:0] bank;
+        logic [$clog2(DEPTH)-1:0] addr;
+        logic reset_mem_done;
+    } self = 0, next_self;
+
+    pipeline_sr #(
+        .DATA_WIDTH(BANK_WIDTH),
+        .ENDING_CYCLE(PIPELINE_DELAY)
+    ) bankb_sr (
+        .clk,
+        .in(bankb),
+        .out(bankb_p)
+    );
+
+    always_ff @(posedge clk) begin
+        state <= next_state;
+        self <= next_self;
+
+        if (reset) begin
+            state <= IDLE;
+            self <= 0;
+        end
+    end
+
+    always_comb begin
+        next_state = state;
+        next_self = self;
+
+        unique case (state)
+        IDLE: begin
+            if (reset_mem)
+                next_state = RESETTING;
+            next_self = 0;
+        end
+        RESETTING: begin
+            if (self.addr == DEPTH - 1) begin
+                next_self.addr = 0;
+                if (self.bank == NUM_BANKS - 1) begin
+                    next_state = IDLE;
+                    next_self.reset_mem_done = 1;
+                end
+                else
+                    next_self.bank = self.bank + 1;
+            end
+            else
+                next_self.addr = self.addr + 1;
+        end
+        endcase
+    end
+
+    always_comb reset_mem_done_pulse = self.reset_mem_done;
+
+    generate
+    genvar i;
+    for (i = 0; i < NUM_BANKS; ++i) begin: bankgen
+        always_comb begin
+            if (state == RESETTING)
+                wea_array[i] = self.bank == i;
+            else
+                wea_array[i] = wea && banka == i;
+
+            reb_array[i] = reb && bankb == i;
+        end
+
+        mem_simple_dual_port #(
+            .DATA_WIDTH(DATA_WIDTH),
+            .DEPTH(DEPTH),
+            .OUTPUT_DELAY(OUTPUT_DELAY),
+            .DEFAULT_VALUE(DEFAULT_VALUE)
+        ) mem_bank (
+            .clka(clk),
+            .clkb(clk),
+            .wea(wea_array[i]),
+            .reb(reb_array[i]),
+            .addra(state == RESETTING ? self.addr : addra),
+            .addrb,
+            .dia(state == RESETTING ? DEFAULT_VALUE : dia),
+            .dob(dob_array[i])
+        );
+    end
+
+    if (OUTPUT_DELAY == 0)
+        always_comb dob = dob_array[bankb];
+    else
+        always_comb dob = dob_array[bankb_p[OUTPUT_DELAY]];
+    endgenerate
+endmodule
+`default_nettype wire

--- a/rtl/soc/sound/opl3/operator.sv
+++ b/rtl/soc/sound/opl3/operator.sv
@@ -46,6 +46,7 @@ module operator
     import opl3_pkg::*;
 (
     input wire clk,
+    input wire reset,
     input wire sample_clk_en,
     input wire is_new,
     input wire [BANK_NUM_WIDTH-1:0] bank_num,

--- a/rtl/soc/sound/opl3/opl3.qip
+++ b/rtl/soc/sound/opl3/opl3.qip
@@ -12,6 +12,7 @@ set_global_assignment -name SYSTEMVERILOG_FILE [file join $::quartus(qip_path) e
 set_global_assignment -name SYSTEMVERILOG_FILE [file join $::quartus(qip_path) host_if.sv ]
 set_global_assignment -name SYSTEMVERILOG_FILE [file join $::quartus(qip_path) ksl_add_rom.sv ]
 set_global_assignment -name SYSTEMVERILOG_FILE [file join $::quartus(qip_path) leds.sv ]
+set_global_assignment -name SYSTEMVERILOG_FILE [file join $::quartus(qip_path) mem_multi_bank_reset.sv ]
 set_global_assignment -name SYSTEMVERILOG_FILE [file join $::quartus(qip_path) mem_multi_bank.sv ]
 set_global_assignment -name SYSTEMVERILOG_FILE [file join $::quartus(qip_path) mem_simple_dual_port.sv ]
 set_global_assignment -name SYSTEMVERILOG_FILE [file join $::quartus(qip_path) operator.sv ]

--- a/rtl/soc/sound/opl3/phase_generator.sv
+++ b/rtl/soc/sound/opl3/phase_generator.sv
@@ -99,7 +99,6 @@ module phase_generator
     logic [OP_OUT_WIDTH+10-1:0] modulation_shifted_p3 = 0;
     logic [PIPELINE_DELAY:1] [$bits(operator_t)-1:0] op_type_p;
 
-
     pipeline_sr #(
         .ENDING_CYCLE(PIPELINE_DELAY)
     ) sample_clk_en_sr (
@@ -280,7 +279,12 @@ module phase_generator
         tmp_ws7_p5[10:0] <= final_phase_p4[19] ? ~final_phase_p4[17:10] << 3 : final_phase_p4[17:10] << 3;
     end
 
-    always_comb log_sin_plus_gain_p5 = (ws_post_opl_p[5] == 7 ? tmp_ws7_p5 : log_sin_out_p5) + (env_p5 << 3);
+    always_comb
+        unique case (ws_post_opl_p[5])
+        6: log_sin_plus_gain_p5 = env_p5 << 3;
+        7: log_sin_plus_gain_p5 = tmp_ws7_p5 + (env_p5 << 3);
+        default: log_sin_plus_gain_p5 = log_sin_out_p5 + (env_p5 << 3);
+        endcase
 
     always_ff @(posedge clk) begin
         final_phase_p5 <= final_phase_p4;
@@ -315,7 +319,7 @@ module phase_generator
         3: tmp_out2_p6 = final_phase_p5[PHASE_ACC_WIDTH-2] ? 0 : tmp_ws2_p6;
         4: tmp_out2_p6 = tmp_ws4_p6;
         5: tmp_out2_p6 = tmp_ws4_p6 < 0 ? ~tmp_ws4_p6 : tmp_ws4_p6;
-        6: tmp_out2_p6 = tmp_out1_p6 > 0 ? 2**(OP_OUT_WIDTH-1) - 1 : -2**(OP_OUT_WIDTH-1);
+        6: tmp_out2_p6 = tmp_out1_p6;
         7: tmp_out2_p6 = tmp_out1_p6;
         endcase
 


### PR DESCRIPTION
Waveform 6 (square wave) had no envelope applied to it so was full blast. Test case was Cybersphere, go to options menu and let it play.

Reset now brings all operator envelopes into the RELEASE state, stopping music on reset.