### PR TITLE
Fix trick sw detection

### DIFF
--- a/rtl/soc/sound/opl3/host_if.sv
+++ b/rtl/soc/sound/opl3/host_if.sv
@@ -68,6 +68,7 @@ module host_if
     logic wr_p1;
     logic wr_p2 = 0;
     logic [REG_FILE_DATA_WIDTH-1:0] host_status;
+    logic [REG_FILE_DATA_WIDTH-1:0] host_status_p1 = 0;
 
     // relax timing on clk_host
     always_ff @(posedge clk_host) begin
@@ -122,10 +123,13 @@ module host_if
         .out(host_status)
     );
 
+    always_ff @(posedge clk_host)
+        host_status_p1 <= host_status;
+
     // Doom DMXOPTION=-opl3-phase detection routine specifically reads address 'b10 to see if it's all ones
     // Decompiled routine provided by Never_Again at https://www.vogons.org/viewtopic.php?f=7&t=100285
-    always_ff @(posedge clk_host)
-        dout <= address_p1 == 0 ? host_status : '1;
+    always_comb
+        dout = address_p1 == 0 ? host_status_p1 : '1;
 
     generate
     if (INSTANTIATE_TIMERS)

--- a/rtl/soc/sound/opl3/trick_sw_detection.sv
+++ b/rtl/soc/sound/opl3/trick_sw_detection.sv
@@ -87,6 +87,7 @@ module trick_sw_detection
     logic [1:0] address_p1 = 0;
     logic [REG_FILE_DATA_WIDTH-1:0] din_p1 = 0;
     logic wr_p1;
+    logic wr_p2 = 0;
     logic [$clog2(NUM_READS_TO_TRIGGER_OVERFLOW)-1:0] host_rd_counter = 0;
     opl3_reg_wr_t host_reg_wr;
     logic rd_p1;
@@ -101,6 +102,7 @@ module trick_sw_detection
         rd_p1_n <= rd_n;
         address_p1 <= address;
         din_p1 <= din;
+        wr_p2 <= wr_p1;
     end
 
     always_comb wr_p1 = !cs_p1_n && !wr_p1_n;
@@ -108,7 +110,7 @@ module trick_sw_detection
     always_ff @(posedge clk_host) begin
         host_reg_wr.valid <= 0;
 
-        if (wr_p1)
+        if (wr_p1 && !wr_p2)
             if (!address_p1[0]) begin // address write mode
                 host_reg_wr.bank_num <= address_p1[1];
                 host_reg_wr.address <= din_p1;


### PR DESCRIPTION
Adlib detection broke in oplclone and Day of the Tentacle after recent timing improvements. Needed to return read value 1 cycle sooner. Additional register on host_status seemed to help timing, so this doesn't look to be degraded timing-wise.