### PR TITLE
Infer async 0-cycle read mems in MLAB LUT RAM

### DIFF
--- a/rtl/soc/sound/opl3/mem_multi_bank.sv
+++ b/rtl/soc/sound/opl3/mem_multi_bank.sv
@@ -62,7 +62,6 @@ module mem_multi_bank #(
     localparam PIPELINE_DELAY = 2;
 
     logic [NUM_BANKS-1:0] wea_array;
-    logic [NUM_BANKS-1:0] reb_array;
     logic [DATA_WIDTH-1:0] dob_array [NUM_BANKS];
     logic [PIPELINE_DELAY:1] [BANK_WIDTH-1:0] bankb_p;
 
@@ -78,26 +77,42 @@ module mem_multi_bank #(
     generate
     genvar i;
     for (i = 0; i < NUM_BANKS; ++i) begin: bankgen
-        always_comb begin
-            wea_array[i] = wea && banka == i;
-            reb_array[i] = reb && bankb == i;
-        end
+        always_comb wea_array[i] = wea && banka == i;
 
-        mem_simple_dual_port #(
-            .DATA_WIDTH(DATA_WIDTH),
-            .DEPTH(DEPTH),
-            .OUTPUT_DELAY(OUTPUT_DELAY),
-            .DEFAULT_VALUE(DEFAULT_VALUE)
-        ) mem_bank (
-            .clka(clk),
-            .clkb(clk),
-            .wea(wea_array[i]),
-            .reb(reb_array[i]),
-            .addra,
-            .addrb,
-            .dia,
-            .dob(dob_array[i])
-        );
+        if (OUTPUT_DELAY == 0)
+            mem_simple_dual_port_async_read #(
+                .DATA_WIDTH(DATA_WIDTH),
+                .DEPTH(DEPTH),
+                .DEFAULT_VALUE(DEFAULT_VALUE)
+            ) mem_bank (
+                .clka(clk),
+                .wea(wea_array[i]),
+                .addra,
+                .addrb,
+                .dia,
+                .dob(dob_array[i])
+            );
+        else begin
+            logic reb_mem;
+
+            always_comb reb_mem = reb && bankb == i;
+
+            mem_simple_dual_port #(
+                .DATA_WIDTH(DATA_WIDTH),
+                .DEPTH(DEPTH),
+                .OUTPUT_DELAY(OUTPUT_DELAY),
+                .DEFAULT_VALUE(DEFAULT_VALUE)
+            ) mem_bank (
+                .clka(clk),
+                .clkb(clk),
+                .wea(wea_array[i]),
+                .reb(reb_mem),
+                .addra,
+                .addrb,
+                .dia,
+                .dob(dob_array[i])
+            );
+        end
     end
 
     if (OUTPUT_DELAY == 0)

--- a/rtl/soc/sound/opl3/mem_multi_bank_reset.sv
+++ b/rtl/soc/sound/opl3/mem_multi_bank_reset.sv
@@ -66,7 +66,6 @@ module mem_multi_bank_reset #(
     localparam PIPELINE_DELAY = 2;
 
     logic [NUM_BANKS-1:0] wea_array;
-    logic [NUM_BANKS-1:0] reb_array;
     logic [DATA_WIDTH-1:0] dob_array [NUM_BANKS];
     logic [PIPELINE_DELAY:1] [BANK_WIDTH-1:0] bankb_p;
 
@@ -131,30 +130,46 @@ module mem_multi_bank_reset #(
     generate
     genvar i;
     for (i = 0; i < NUM_BANKS; ++i) begin: bankgen
-        always_comb begin
+        always_comb
             if (state == RESETTING)
                 wea_array[i] = self.bank == i;
             else
                 wea_array[i] = wea && banka == i;
 
-            reb_array[i] = reb && bankb == i;
-        end
+        if (OUTPUT_DELAY == 0)
+            mem_simple_dual_port_async_read #(
+                .DATA_WIDTH(DATA_WIDTH),
+                .DEPTH(DEPTH),
+                .DEFAULT_VALUE(DEFAULT_VALUE)
+            ) mem_bank (
+                .clka(clk),
+                .wea(wea_array[i]),
+                .addra(state == RESETTING ? self.addr : addra),
+                .addrb,
+                .dia(state == RESETTING ? DEFAULT_VALUE : dia),
+                .dob(dob_array[i])
+            );
+        else begin
+            logic reb_mem;
 
-        mem_simple_dual_port #(
-            .DATA_WIDTH(DATA_WIDTH),
-            .DEPTH(DEPTH),
-            .OUTPUT_DELAY(OUTPUT_DELAY),
-            .DEFAULT_VALUE(DEFAULT_VALUE)
-        ) mem_bank (
-            .clka(clk),
-            .clkb(clk),
-            .wea(wea_array[i]),
-            .reb(reb_array[i]),
-            .addra(state == RESETTING ? self.addr : addra),
-            .addrb,
-            .dia(state == RESETTING ? DEFAULT_VALUE : dia),
-            .dob(dob_array[i])
-        );
+            always_comb reb_mem = reb && bankb == i;
+
+            mem_simple_dual_port #(
+                .DATA_WIDTH(DATA_WIDTH),
+                .DEPTH(DEPTH),
+                .OUTPUT_DELAY(OUTPUT_DELAY),
+                .DEFAULT_VALUE(DEFAULT_VALUE)
+            ) mem_bank (
+                .clka(clk),
+                .clkb(clk),
+                .wea(wea_array[i]),
+                .reb(reb_mem),
+                .addra(state == RESETTING ? self.addr : addra),
+                .addrb,
+                .dia(state == RESETTING ? DEFAULT_VALUE : dia),
+                .dob(dob_array[i])
+            );
+        end
     end
 
     if (OUTPUT_DELAY == 0)

--- a/rtl/soc/sound/opl3/opl3.qip
+++ b/rtl/soc/sound/opl3/opl3.qip
@@ -14,6 +14,7 @@ set_global_assignment -name SYSTEMVERILOG_FILE [file join $::quartus(qip_path) k
 set_global_assignment -name SYSTEMVERILOG_FILE [file join $::quartus(qip_path) leds.sv ]
 set_global_assignment -name SYSTEMVERILOG_FILE [file join $::quartus(qip_path) mem_multi_bank_reset.sv ]
 set_global_assignment -name SYSTEMVERILOG_FILE [file join $::quartus(qip_path) mem_multi_bank.sv ]
+set_global_assignment -name SYSTEMVERILOG_FILE [file join $::quartus(qip_path) mem_simple_dual_port_async_read.sv ]
 set_global_assignment -name SYSTEMVERILOG_FILE [file join $::quartus(qip_path) mem_simple_dual_port.sv ]
 set_global_assignment -name SYSTEMVERILOG_FILE [file join $::quartus(qip_path) operator.sv ]
 set_global_assignment -name SYSTEMVERILOG_FILE [file join $::quartus(qip_path) opl3_exp_lut.sv ]


### PR DESCRIPTION
Savings of ~1000 ALMs give or take depending on the run. Substantial.