### PR TITLE
Fix rhythm operators

### DIFF
--- a/rtl/soc/sound/opl3/calc_rhythm_phase.sv
+++ b/rtl/soc/sound/opl3/calc_rhythm_phase.sv
@@ -9,6 +9,9 @@
 #   Simply passes through the unmodified phase otherwise.
 #
 #   CHANGE HISTORY:
+#   3 June 2024     Greg Taylor
+#       Refactored to match implementation in https://github.com/nukeykt/Nuked-OPL3
+#
 #   25 July 2015    Greg Taylor
 #       Initial version
 #
@@ -33,7 +36,7 @@
 #   Copyright (C) 2008 Robson Cozendey <robson@cozendey.com>
 #
 #   Original C++ Code:
-#   Copyright (C) 2012  Steffen Ohrendorf <steffen.ohrendorf@gmx.de>
+#   Copyright (C) 2013-2020 Nuke.YKT
 #
 #   Some code based on forum posts in:
 #   http://forums.submarine.org.uk/phpBB/viewforum.php?f=9,
@@ -52,21 +55,24 @@ module calc_rhythm_phase
     input wire sample_clk_en,
     input wire [BANK_NUM_WIDTH-1:0] bank_num,
     input wire [OP_NUM_WIDTH-1:0] op_num,
-    input wire [PHASE_ACC_WIDTH-1:0] phase_acc_p3,
-    input var operator_t op_type,
-    output logic [PHASE_ACC_WIDTH-1:0] rhythm_phase_p3
+    input wire [PHASE_FINAL_WIDTH-1:0] phase_p2,
+    input var operator_t op_type_p0,
+    output logic [PHASE_FINAL_WIDTH-1:0] rhythm_phase_p3 = 0
 );
     localparam PIPELINE_DELAY = 3;
     localparam RAND_POLYNOMIAL = 'h800302; // verified on real opl3
     localparam RAND_NUM_WIDTH = $clog2(RAND_POLYNOMIAL);
 
-    logic [PHASE_ACC_WIDTH-1:0] hh_phase_friend = 0;
-    logic [PHASE_ACC_WIDTH-1:0] hh_phase_p3;
-    logic [PHASE_ACC_WIDTH-1:0] phase_bit_p3;
-    logic [PHASE_ACC_WIDTH-1:0] noise_bit_p3;
+    logic [PHASE_FINAL_WIDTH-1:0] hh_phase_friend = 0;
+    logic [PHASE_FINAL_WIDTH-1:0] tc_phase_friend = 0;
+    logic [PHASE_FINAL_WIDTH-1:0] hh_phase_p2;
+    logic [PHASE_FINAL_WIDTH-1:0] tc_phase_p2;
+    logic rm_xor_p2;
     logic [RAND_NUM_WIDTH-1:0] rand_num = 1;
     logic [PIPELINE_DELAY:1] sample_clk_en_p;
     logic [PIPELINE_DELAY:1] [$bits(operator_t)-1:0] op_type_p;
+    logic [PIPELINE_DELAY:1] [BANK_NUM_WIDTH-1:0] bank_num_p;
+    logic [PIPELINE_DELAY:1] [OP_NUM_WIDTH-1:0] op_num_p;
 
     pipeline_sr #(
         .ENDING_CYCLE(PIPELINE_DELAY)
@@ -82,40 +88,54 @@ module calc_rhythm_phase
         .POR_VALUE(OP_NORMAL)
     ) op_type_sr (
         .clk,
-        .in(op_type),
+        .in(op_type_p0),
         .out(op_type_p)
     );
 
-    // Store the hi hat phase when it comes by. It's used in the top symbol and snare drum operators
-    always_ff @(posedge clk)
-        if (sample_clk_en_p[3] && bank_num == 0 && op_num == 13)
-            hh_phase_friend <= phase_acc_p3;
+    pipeline_sr #(
+        .DATA_WIDTH(BANK_NUM_WIDTH),
+        .ENDING_CYCLE(PIPELINE_DELAY)
+    ) bank_num_sr (
+        .clk,
+        .in(bank_num),
+        .out(bank_num_p)
+    );
 
-    always_comb begin
-        // used in hi hat, top cymbal, and snare drum
-        unique case (op_type_p[3])
-        OP_SNARE_DRUM: hh_phase_p3 = (hh_phase_friend & 'h100) ? 'h200 : 'h100;
-        OP_TOP_CYMBAL: hh_phase_p3 = hh_phase_friend;
-        default:       hh_phase_p3 = phase_acc_p3; // hi hat
-        endcase
+    pipeline_sr #(
+        .DATA_WIDTH(OP_NUM_WIDTH),
+        .ENDING_CYCLE(PIPELINE_DELAY)
+    ) op_num_sr (
+        .clk,
+        .in(op_num),
+        .out(op_num_p)
+    );
 
-        // used in hi hat and top cymbal
-        phase_bit_p3 = (((hh_phase_p3 & 'h88) ^ ((hh_phase_p3 << 5) & 'h80)) |
-         ((hh_phase_p3 ^ (hh_phase_p3 << 2)) & 'h20)) ? 'h02 : 'h00;
+    always_ff @(posedge clk) begin
+        // Store the hi hat phase when it comes by
+        if (sample_clk_en_p[2] && bank_num_p[2] == 0 && op_num_p[2] == 13)
+            hh_phase_friend <= phase_p2;
 
-        // used in hi hat and snare drum
-        noise_bit_p3 = op_type_p[3] == OP_HI_HAT ? rand_num[0] << 1 : rand_num[0] << 8;
+        // Store the top cymbal phase when it comes by
+        if (sample_clk_en_p[2] && bank_num_p[2] == 0 && op_num_p[2] == 17)
+            tc_phase_friend <= phase_p2;
     end
 
-    always_comb
-        unique case (op_type_p[3])
-        OP_NORMAL:     rhythm_phase_p3 = phase_acc_p3;
-        OP_BASS_DRUM:  rhythm_phase_p3 = phase_acc_p3;
-        OP_HI_HAT:     rhythm_phase_p3 = (phase_bit_p3 << 8) | ('h34 << (phase_bit_p3 ^ noise_bit_p3));
-        OP_TOM_TOM:    rhythm_phase_p3 = phase_acc_p3;
-        OP_SNARE_DRUM: rhythm_phase_p3 = hh_phase_p3 ^ noise_bit_p3;
-        OP_TOP_CYMBAL: rhythm_phase_p3 = (1 + phase_bit_p3) << 8;
+    always_comb begin
+        hh_phase_p2 = op_type_p[2] == OP_HI_HAT ? phase_p2 : hh_phase_friend;
+        tc_phase_p2 = op_type_p[2] == OP_TOP_CYMBAL ? phase_p2 : tc_phase_friend;
+        rm_xor_p2 = (hh_phase_p2[2] ^ hh_phase_p2[7]) ||
+                    (hh_phase_p2[3] ^ tc_phase_p2[5]) ||
+                    (tc_phase_p2[3] ^ tc_phase_p2[5]);
+    end
+
+    always_ff @(posedge clk) begin
+        unique case (op_type_p[2])
+        OP_HI_HAT:     rhythm_phase_p3 <= (rm_xor_p2 << 9) | ((rm_xor_p2 ^ rand_num[0]) ? 'hd0 : 'h34);
+        OP_SNARE_DRUM: rhythm_phase_p3 <= (hh_phase_p2[8] << 9) | ((hh_phase_p2[8] ^ rand_num[0]) << 8);
+        OP_TOP_CYMBAL: rhythm_phase_p3 <= (rm_xor_p2 << 9) | 'h80;
+        default:       rhythm_phase_p3 <= phase_p2; // all others pass through
         endcase
+    end
 
     always_ff @(posedge clk)
         /*

--- a/rtl/soc/sound/opl3/channels.sv
+++ b/rtl/soc/sound/opl3/channels.sv
@@ -54,8 +54,7 @@ module channels
     output logic signed [DAC_OUTPUT_WIDTH-1:0] sample_l,
     output logic signed [DAC_OUTPUT_WIDTH-1:0] sample_r
 );
-    localparam CHAN_2_OP_WIDTH = OP_OUT_WIDTH + 1;
-    localparam CHAN_4_OP_WIDTH = OP_OUT_WIDTH + 2;
+    localparam CHANNEL_OUT_WIDTH = OP_OUT_WIDTH + 2;
 
     // + 1 because we combine 2 channels together for left and right
     localparam CHANNEL_ACCUMULATOR_WIDTH = OP_OUT_WIDTH + $clog2(NUM_OPERATORS_PER_BANK*NUM_BANKS) + 1;
@@ -155,8 +154,7 @@ module channels
         logic [$clog2(NUM_OPERATORS_PER_BANK)-1:0] op_mem_op_num;
         logic op_mem_rd;
         logic [$clog2(NUM_CHANNELS_PER_BANK)-1:0] ch_abcd_cnt_mem_channel_num;
-        logic signed [CHAN_2_OP_WIDTH-1:0] channel_2_op;
-        logic signed [CHAN_4_OP_WIDTH-1:0] channel_4_op;
+        logic signed [CHANNEL_OUT_WIDTH-1:0] channel_out;
         logic latch_channels;
         logic add_a;
         logic add_b;
@@ -197,11 +195,11 @@ module channels
         end
         LOAD_2_OP_FIRST_AND_ACCUMULATE: begin
             signals.ch_abcd_cnt_mem_channel_num = self.channel_num;
-            signals.channel_2_op = cnt ? operator_mem_out + self.operator_out_second : self.operator_out_second;
+            signals.channel_out = cnt ? operator_mem_out + self.operator_out_second : self.operator_out_second;
             if (ryt && self.bank_num == 0)
                 unique case (self.channel_num)
-                6:    signals.channel_2_op = cnt ? self.operator_out_second : operator_mem_out; // bass drum
-                7, 8: signals.channel_2_op = operator_mem_out + self.operator_out_second; // hi-hat and snare drum, tom-tom and top cymbal
+                6:    signals.channel_out = self.operator_out_second*2; // bass drum
+                7, 8: signals.channel_out = (operator_mem_out + self.operator_out_second)*2; // hi-hat and snare drum, tom-tom and top cymbal
                 default:;
                 endcase
 
@@ -241,14 +239,14 @@ module channels
             end
 
             unique case ({signals.add_a, signals.add_c})
-            'b01, 'b10: next_self.channel_l_acc_pre_clamp = self.channel_l_acc_pre_clamp + signals.channel_2_op;
-            'b11:       next_self.channel_l_acc_pre_clamp = self.channel_l_acc_pre_clamp + signals.channel_2_op*2;
+            'b01, 'b10: next_self.channel_l_acc_pre_clamp = self.channel_l_acc_pre_clamp + signals.channel_out;
+            'b11:       next_self.channel_l_acc_pre_clamp = self.channel_l_acc_pre_clamp + signals.channel_out*2;
             default:;
             endcase
 
             unique case ({signals.add_b, signals.add_d})
-            'b01, 'b10: next_self.channel_r_acc_pre_clamp = self.channel_r_acc_pre_clamp + signals.channel_2_op;
-            'b11:       next_self.channel_r_acc_pre_clamp = self.channel_r_acc_pre_clamp + signals.channel_2_op*2;
+            'b01, 'b10: next_self.channel_r_acc_pre_clamp = self.channel_r_acc_pre_clamp + signals.channel_out;
+            'b11:       next_self.channel_r_acc_pre_clamp = self.channel_r_acc_pre_clamp + signals.channel_out*2;
             default:;
             endcase
 
@@ -300,10 +298,10 @@ module channels
         LOAD_4_OP_FIRST_AND_ACCUMULATE: begin
             signals.ch_abcd_cnt_mem_channel_num = self.channel_num;
             unique case ({cnt, self.cnt_second})
-            'b00: signals.channel_4_op = self.operator_out_third;
-            'b01: signals.channel_4_op = operator_mem_out + self.operator_out_third;
-            'b10: signals.channel_4_op = operator_mem_out + self.operator_out_third;
-            'b11: signals.channel_4_op = operator_mem_out + self.operator_out_second + self.operator_out_third;
+            'b00: signals.channel_out = self.operator_out_third;
+            'b01: signals.channel_out = operator_mem_out + self.operator_out_third;
+            'b10: signals.channel_out = operator_mem_out + self.operator_out_third;
+            'b11: signals.channel_out = operator_mem_out + self.operator_out_second + self.operator_out_third;
             endcase
 
             if (self.bank_num == 0) begin
@@ -324,14 +322,14 @@ module channels
             * after the YAC512 DAC outputs. Here we'll just add digitally.
             */
             unique case ({signals.add_a, signals.add_c})
-            'b01, 'b10: next_self.channel_l_acc_pre_clamp = self.channel_l_acc_pre_clamp + signals.channel_4_op;
-            'b11:       next_self.channel_l_acc_pre_clamp = self.channel_l_acc_pre_clamp + signals.channel_4_op*2;
+            'b01, 'b10: next_self.channel_l_acc_pre_clamp = self.channel_l_acc_pre_clamp + signals.channel_out;
+            'b11:       next_self.channel_l_acc_pre_clamp = self.channel_l_acc_pre_clamp + signals.channel_out*2;
             default:;
             endcase
 
             unique case ({signals.add_b, signals.add_d})
-            'b01, 'b10: next_self.channel_r_acc_pre_clamp = self.channel_r_acc_pre_clamp + signals.channel_4_op;
-            'b11:       next_self.channel_r_acc_pre_clamp = self.channel_r_acc_pre_clamp + signals.channel_4_op*2;
+            'b01, 'b10: next_self.channel_r_acc_pre_clamp = self.channel_r_acc_pre_clamp + signals.channel_out;
+            'b11:       next_self.channel_r_acc_pre_clamp = self.channel_r_acc_pre_clamp + signals.channel_out*2;
             default:;
             endcase
 

--- a/rtl/soc/sound/opl3/control_operators.sv
+++ b/rtl/soc/sound/opl3/control_operators.sv
@@ -73,7 +73,6 @@ module control_operators
 
     logic use_feedback_p1 = 0;
     logic signed [OP_OUT_WIDTH-1:0] modulation_p1 = 0;
-    operator_t op_type;
     logic signed [OP_OUT_WIDTH-1:0] out_p6;
     logic signed [OP_OUT_WIDTH-1:0] modulation_out_p1;
 
@@ -386,22 +385,8 @@ module control_operators
            else               use_feedback_p1 <= !connection_sel[4];
         8: if (bank_num == 0) use_feedback_p1 <= !connection_sel[2];
            else               use_feedback_p1 <= !connection_sel[5];
-        13:                   use_feedback_p1 <= !(bank_num == 0 && ryt); // aka hi hat operator in bank 0
-        14:                   use_feedback_p1 <= !(bank_num == 0 && ryt); // aka tom tom operator in bank 0
+        13, 14:               use_feedback_p1 <= !(bank_num == 0 && ryt); // hi-hat and tom-tom do not use feedback
         endcase
-
-    always_comb begin
-        op_type = OP_NORMAL;
-        if (bank_num == 0 && ryt)
-            unique case (op_num)
-            12, 15:  op_type = OP_BASS_DRUM;
-            13:      op_type = OP_HI_HAT;
-            14:      op_type = OP_TOM_TOM;
-            16:      op_type = OP_SNARE_DRUM;
-            17:      op_type = OP_TOP_CYMBAL;
-            default: op_type = OP_NORMAL;
-            endcase
-    end
 
     always_ff @(posedge clk) begin
         bank_num_p1 <= bank_num;
@@ -456,8 +441,7 @@ module control_operators
                 'b11:             modulation_p1 = 0;
                 endcase
             else                  modulation_p1 = cnt0_p1 ? 0 : modulation_out_p1;
-        16:                       modulation_p1 = cnt0_p1 || (ryt_p1 && bank_num_p1 == 0) ? 0 : modulation_out_p1; // aka snare drum operator in bank 0
-        17:                       modulation_p1 = cnt0_p1 || (ryt_p1 && bank_num_p1 == 0) ? 0 : modulation_out_p1; // aka top cymbal operator in bank 0
+        16, 17:                   modulation_p1 = cnt0_p1 || (ryt_p1 && bank_num_p1 == 0) ? 0 : modulation_out_p1; // snare drum and top cymbal do not use modulation
         endcase
 
     always_ff @(posedge clk)

--- a/rtl/soc/sound/opl3/edge_detector.sv
+++ b/rtl/soc/sound/opl3/edge_detector.sv
@@ -62,23 +62,27 @@ module edge_detector #(
     logic in_r1 = INITIAL_INPUT_LEVEL;
 
     always_ff @(posedge clk)
-    	if (!CLK_DLY)
-            in_r0 <= in;
-        else if (clk_en) begin
-            in_r0 <= in;
-            in_r1 <= in_r0;
+        if (clk_en) begin
+            if (!CLK_DLY)
+                in_r0 <= in;
+            else begin
+                in_r0 <= in;
+                in_r1 <= in_r0;
+            end
         end
 
     always_comb
-        if (EDGE_LEVEL)
+        if (EDGE_LEVEL) begin
             if (!CLK_DLY)
-                edge_detected = in && !in_r0;
+                edge_detected = clk_en && in && !in_r0;
             else
                 edge_detected = in_r0 && !in_r1;
-        else
+        end
+        else begin
             if (!CLK_DLY)
-                edge_detected = !in && in_r0;
+                edge_detected = clk_en && !in && in_r0;
             else
                 edge_detected = !in_r0 && in_r1;
+        end
 endmodule
 `default_nettype wire

--- a/rtl/soc/sound/opl3/env_rate_counter.sv
+++ b/rtl/soc/sound/opl3/env_rate_counter.sv
@@ -54,7 +54,6 @@ module env_rate_counter
     input wire [REG_FNUM_WIDTH-1:0] fnum,
     input wire [REG_BLOCK_WIDTH-1:0] block,
     input wire [REG_ENV_WIDTH-1:0] requested_rate_p0,
-    input wire key_on_pulse_p0,
     output logic [ENV_RATE_COUNTER_OVERFLOW_WIDTH-1:0] rate_counter_overflow_p1 = 0
 );
     localparam COUNTER_WIDTH = 15;
@@ -68,7 +67,6 @@ module env_rate_counter
     logic [$clog2(60)-2-1:0] rate_value_p1;
     logic [REG_ENV_WIDTH+2-1:0] requested_rate_shifted_p0;
     logic [1:0] rof_p1;
-    logic [COUNTER_WIDTH-1:0] counter_fifo_out_p1;
     logic [COUNTER_WIDTH-1:0] counter_p1;
     logic [COUNTER_WIDTH-1:0] counter_new_p2;
     logic [$clog2(OVERFLOW_TMP_MAX_VALUE)-1:0] overflow_tmp_p1;
@@ -141,14 +139,10 @@ module env_rate_counter
         .bankb(bank_num),
         .addrb(op_num),
         .dia(counter_new_p2),
-        .dob(counter_fifo_out_p1)
+        .dob(counter_p1)
     );
 
-    always_ff @(posedge clk)
-        key_on_pulse_p1 <= key_on_pulse_p0;
-
     always_comb begin
-        counter_p1 = key_on_pulse_p1 ? 0 : counter_fifo_out_p1;
         overflow_tmp_p1 = counter_p1 + ((4 | rof_p1) << rate_value_p1);
         rate_counter_overflow_p1 = overflow_tmp_p1 >> 15;
     end

--- a/rtl/soc/sound/opl3/operator.sv
+++ b/rtl/soc/sound/opl3/operator.sv
@@ -74,10 +74,10 @@ module operator
     input wire tom,
     input wire tc,
     input wire hh,
+    input wire ryt,
     input wire use_feedback_p1,
     input wire [REG_FB_WIDTH-1:0] fb_p1,
     input wire signed [OP_OUT_WIDTH-1:0] modulation_p1,
-    input var operator_t op_type,
     output logic signed [OP_OUT_WIDTH-1:0] out_p6
 );
     localparam PIPELINE_DELAY = 6;
@@ -91,17 +91,26 @@ module operator
     logic [ENV_WIDTH-1:0] env_p3;
     logic signed [OP_OUT_WIDTH-1:0] feedback_result_p1;
     logic signed [OP_OUT_WIDTH+1+2**REG_FB_WIDTH-1:0] feedback_result_tmp_p1;
-    logic bd_on_pulse;
-    logic sd_on_pulse;
-    logic tom_on_pulse;
-    logic tc_on_pulse;
-    logic hh_on_pulse;
-    logic rhythm_kon_pulse;
+    logic bd0_on_pulse_p0;
+    logic bd1_on_pulse_p0;
+    logic sd_on_pulse_p0;
+    logic tom_on_pulse_p0;
+    logic tc_on_pulse_p0;
+    logic hh_on_pulse_p0;
+    logic rhythm_kon_pulse_p0;
+    logic bd0_off_pulse_p0;
+    logic bd1_off_pulse_p0;
+    logic sd_off_pulse_p0;
+    logic tom_off_pulse_p0;
+    logic tc_off_pulse_p0;
+    logic hh_off_pulse_p0;
+    logic rhythm_koff_pulse_p0;
     logic prev_kon_p0;
     logic kon_p1;
     logic [1:0] [OP_OUT_WIDTH-1:0] feedback_p1;
     logic [1:0] [OP_OUT_WIDTH-1:0] feedback_p6;
     logic [PIPELINE_DELAY:2] [1:0] [OP_OUT_WIDTH-1:0] feedback_p;
+    operator_t op_type_p0;
 
     pipeline_sr #(
         .ENDING_CYCLE(PIPELINE_DELAY)
@@ -150,68 +159,155 @@ module operator
         .dob(prev_kon_p0)
     );
 
+    always_comb begin
+        op_type_p0 = OP_NORMAL;
+        if (bank_num == 0 && ryt)
+            unique case (op_num)
+            12, 15:  op_type_p0 = OP_BASS_DRUM;
+            13:      op_type_p0 = OP_HI_HAT;
+            14:      op_type_p0 = OP_TOM_TOM;
+            16:      op_type_p0 = OP_SNARE_DRUM;
+            17:      op_type_p0 = OP_TOP_CYMBAL;
+            default: op_type_p0 = OP_NORMAL;
+            endcase
+    end
+
     edge_detector #(
         .EDGE_LEVEL(1),
         .CLK_DLY(0)
-    ) bd_edge_detect (
-        .clk_en(op_type == OP_BASS_DRUM && sample_clk_en),
+    ) bd0_on_edge_detect (
+        .clk_en(ryt && sample_clk_en && bank_num == 0 && op_num == 12),
         .in(bd),
-        .edge_detected(bd_on_pulse),
+        .edge_detected(bd0_on_pulse_p0),
         .*
     );
     edge_detector #(
         .EDGE_LEVEL(1),
         .CLK_DLY(0)
-    ) sd_edge_detect (
-        .clk_en(op_type == OP_SNARE_DRUM && sample_clk_en),
+    ) bd1_on_edge_detect (
+        .clk_en(ryt && sample_clk_en && bank_num == 0 && op_num == 15),
+        .in(bd),
+        .edge_detected(bd1_on_pulse_p0),
+        .*
+    );
+    edge_detector #(
+        .EDGE_LEVEL(1),
+        .CLK_DLY(0)
+    ) sd_on_edge_detect (
+        .clk_en(op_type_p0 == OP_SNARE_DRUM && sample_clk_en),
         .in(sd),
-        .edge_detected(sd_on_pulse),
+        .edge_detected(sd_on_pulse_p0),
         .*
     );
     edge_detector #(
         .EDGE_LEVEL(1),
         .CLK_DLY(0)
-    ) tom_edge_detect (
-        .clk_en(op_type == OP_TOM_TOM && sample_clk_en),
+    ) tom_on_edge_detect (
+        .clk_en(op_type_p0 == OP_TOM_TOM && sample_clk_en),
         .in(tom),
-        .edge_detected(tom_on_pulse),
+        .edge_detected(tom_on_pulse_p0),
         .*
     );
     edge_detector #(
         .EDGE_LEVEL(1),
         .CLK_DLY(0)
-    ) tc_edge_detect (
-        .clk_en(op_type == OP_TOP_CYMBAL && sample_clk_en),
+    ) tc_on_edge_detect (
+        .clk_en(op_type_p0 == OP_TOP_CYMBAL && sample_clk_en),
         .in(tc),
-        .edge_detected(tc_on_pulse),
+        .edge_detected(tc_on_pulse_p0),
         .*
     );
     edge_detector #(
         .EDGE_LEVEL(1),
         .CLK_DLY(0)
-    ) hh_edge_detect (
-        .clk_en(op_type == OP_HI_HAT && sample_clk_en),
+    ) hh_on_edge_detect (
+        .clk_en(op_type_p0 == OP_HI_HAT && sample_clk_en),
         .in(hh),
-        .edge_detected(hh_on_pulse),
+        .edge_detected(hh_on_pulse_p0),
         .*
     );
 
-    always_comb rhythm_kon_pulse =
-     (op_type == OP_BASS_DRUM && bd_on_pulse) ||
-     (op_type == OP_SNARE_DRUM && sd_on_pulse) ||
-     (op_type == OP_TOM_TOM && tom_on_pulse) ||
-     (op_type == OP_TOP_CYMBAL && tc_on_pulse) ||
-     (op_type == OP_HI_HAT && hh_on_pulse);
+    edge_detector #(
+        .EDGE_LEVEL(0),
+        .CLK_DLY(0)
+    ) bd0_off_edge_detect (
+        .clk_en(ryt && sample_clk_en && bank_num == 0 && op_num == 12),
+        .in(bd),
+        .edge_detected(bd0_off_pulse_p0),
+        .*
+    );
+    edge_detector #(
+        .EDGE_LEVEL(0),
+        .CLK_DLY(0)
+    ) bd1_off_edge_detect (
+        .clk_en(ryt && sample_clk_en && bank_num == 0 && op_num == 15),
+        .in(bd),
+        .edge_detected(bd1_off_pulse_p0),
+        .*
+    );
+    edge_detector #(
+        .EDGE_LEVEL(0),
+        .CLK_DLY(0)
+    ) sd_off_edge_detect (
+        .clk_en(op_type_p0 == OP_SNARE_DRUM && sample_clk_en),
+        .in(sd),
+        .edge_detected(sd_off_pulse_p0),
+        .*
+    );
+    edge_detector #(
+        .EDGE_LEVEL(0),
+        .CLK_DLY(0)
+    ) tom_off_edge_detect (
+        .clk_en(op_type_p0 == OP_TOM_TOM && sample_clk_en),
+        .in(tom),
+        .edge_detected(tom_off_pulse_p0),
+        .*
+    );
+    edge_detector #(
+        .EDGE_LEVEL(0),
+        .CLK_DLY(0)
+    ) tc_off_edge_detect (
+        .clk_en(op_type_p0 == OP_TOP_CYMBAL && sample_clk_en),
+        .in(tc),
+        .edge_detected(tc_off_pulse_p0),
+        .*
+    );
+    edge_detector #(
+        .EDGE_LEVEL(0),
+        .CLK_DLY(0)
+    ) hh_off_edge_detect (
+        .clk_en(op_type_p0 == OP_HI_HAT && sample_clk_en),
+        .in(hh),
+        .edge_detected(hh_off_pulse_p0),
+        .*
+    );
 
-    always_comb key_on_pulse_p0 = ((!prev_kon_p0 && kon) || rhythm_kon_pulse) && sample_clk_en;
-    always_comb key_off_pulse_p0 = prev_kon_p0 && !kon && sample_clk_en;
+    always_comb begin
+        rhythm_kon_pulse_p0 =
+            bd0_on_pulse_p0 ||
+            bd1_on_pulse_p0 ||
+            sd_on_pulse_p0 ||
+            tom_on_pulse_p0 ||
+            tc_on_pulse_p0 ||
+            hh_on_pulse_p0;
+
+        rhythm_koff_pulse_p0 =
+            bd0_off_pulse_p0 ||
+            bd1_off_pulse_p0 ||
+            sd_off_pulse_p0 ||
+            tom_off_pulse_p0 ||
+            tc_off_pulse_p0 ||
+            hh_off_pulse_p0;
+
+        key_on_pulse_p0 = (!prev_kon_p0 && kon) || rhythm_kon_pulse_p0;
+        key_off_pulse_p0 = (prev_kon_p0 && !kon) || rhythm_koff_pulse_p0;
+    end
 
     calc_phase_inc calc_phase_inc (
         .*
     );
 
     envelope_generator envelope_generator (
-        .egt(egt && op_type == OP_NORMAL),
         .*
     );
 

--- a/rtl/soc/sound/opl3/opl3_pkg.sv
+++ b/rtl/soc/sound/opl3/opl3_pkg.sv
@@ -65,10 +65,11 @@ package opl3_pkg;
     localparam REG_FB_WIDTH = 3;
 
     localparam SAMPLE_WIDTH = 16;
-    localparam DAC_LEFT_SHIFT = signed'(DAC_OUTPUT_WIDTH - SAMPLE_WIDTH - 2) < 0 ? 0 : DAC_OUTPUT_WIDTH - SAMPLE_WIDTH - 2;
+    localparam DAC_LEFT_SHIFT = signed'(DAC_OUTPUT_WIDTH - SAMPLE_WIDTH - 2) < 0 ? 0 : DAC_OUTPUT_WIDTH - SAMPLE_WIDTH - 3;
     localparam ENV_WIDTH = 9;
     localparam OP_OUT_WIDTH = 13;
     localparam PHASE_ACC_WIDTH = 20;
+    localparam PHASE_FINAL_WIDTH = 10;
     localparam VIB_VAL_WIDTH = REG_FNUM_WIDTH - 7;
     localparam ENV_RATE_COUNTER_OVERFLOW_WIDTH = $clog2(7);
     localparam TREMOLO_MAX_COUNT = 13*1024;

--- a/rtl/soc/sound/opl3/phase_generator.sv
+++ b/rtl/soc/sound/opl3/phase_generator.sv
@@ -7,6 +7,9 @@
 #   DESCRIPTION:
 #
 #   CHANGE HISTORY:
+#   3 June 2024     Greg Taylor
+#       Refactored to match implementation in https://github.com/nukeykt/Nuked-OPL3
+#
 #   13 Oct 2014    Greg Taylor
 #       Initial version
 #
@@ -31,7 +34,7 @@
 #   Copyright (C) 2008 Robson Cozendey <robson@cozendey.com>
 #
 #   Original C++ Code:
-#   Copyright (C) 2012  Steffen Ohrendorf <steffen.ohrendorf@gmx.de>
+#   Copyright (C) 2013-2020 Nuke.YKT
 #
 #   Some code based on forum posts in:
 #   http://forums.submarine.org.uk/phpBB/viewforum.php?f=9,
@@ -55,49 +58,36 @@ module phase_generator
     input wire [ENV_WIDTH-1:0] env_p3,
     input wire key_on_pulse_p0,
     input wire [OP_OUT_WIDTH-1:0] modulation_p1,
-    input var operator_t op_type,
+    input var operator_t op_type_p0,
     output logic signed [OP_OUT_WIDTH-1:0] out_p6 = 0
 );
     localparam LOG_SIN_OUT_WIDTH = 12;
-    localparam EXP_IN_WIDTH = 8;
     localparam EXP_OUT_WIDTH = 10;
-    localparam LOG_SIN_PLUS_GAIN_WIDTH = 13;
     localparam PIPELINE_DELAY = 6;
 
     logic [PIPELINE_DELAY:1] sample_clk_en_p;
     logic [PIPELINE_DELAY:1] key_on_pulse_p;
     logic [PHASE_ACC_WIDTH-1:0] phase_acc_p2;
     logic [PHASE_ACC_WIDTH-1:0] phase_acc_p3 = 0;
-    logic [PHASE_ACC_WIDTH-1:0] final_phase_p4 = 0;
-    logic [PHASE_ACC_WIDTH-1:0] final_phase_p5 = 0;
-    logic prev_final_phase_msb_p2;
-    logic prev_final_phase_msb_p3 = 0;
-    logic prev_final_phase_msb_p4 = 0;
-    logic is_odd_period_p2;
-    logic is_odd_period_p3 = 0;
-    logic is_odd_period_p4 = 0;
-    logic is_odd_period_p5 = 0;
-    logic is_odd_period_p6 = 0;
-    logic [PHASE_ACC_WIDTH-1:0] rhythm_phase_p3;
-    logic [LOG_SIN_OUT_WIDTH-1:0] log_sin_out_p5;
-    logic [LOG_SIN_PLUS_GAIN_WIDTH-1:0] log_sin_plus_gain_p5 = 0;
-    logic [LOG_SIN_PLUS_GAIN_WIDTH-1:0] log_sin_plus_gain_p6 = 0;
-    logic [EXP_OUT_WIDTH-1:0] exp_out_p6;
-    logic [OP_OUT_WIDTH-1:0] tmp_out0_p6;
-    logic signed [OP_OUT_WIDTH-1:0] tmp_out1_p6;
-    logic signed [OP_OUT_WIDTH-1:0] tmp_out2_p6;
-    logic signed [OP_OUT_WIDTH-1:0] tmp_ws2_p6;
-    logic signed [OP_OUT_WIDTH-1:0] tmp_ws4_p6;
-    logic [LOG_SIN_OUT_WIDTH-1:0] tmp_ws7_p5 = 0;
+    logic [PHASE_FINAL_WIDTH-1:0] final_phase_p3;
+    logic [7:0] theta_p3;
+    logic [PHASE_FINAL_WIDTH-1:0] rhythm_phase_p3;
+    logic [LOG_SIN_OUT_WIDTH-1:0] log_sin_out_p4;
+    logic [OP_OUT_WIDTH-1:0] pre_gain_p4;
+    logic [OP_OUT_WIDTH:0] post_gain_p4; // need extra bit to detect overflow
     logic [REG_WS_WIDTH-1:0] ws_post_opl_p0;
     logic [PIPELINE_DELAY:1] [REG_WS_WIDTH-1:0] ws_post_opl_p;
-    logic [ENV_WIDTH-1:0] env_p4 = 0;
-    logic [ENV_WIDTH-1:0] env_p5 = 0;
     logic [PIPELINE_DELAY:1] [BANK_NUM_WIDTH-1:0] bank_num_p;
     logic [PIPELINE_DELAY:1] [OP_NUM_WIDTH-1:0] op_num_p;
-    logic [OP_OUT_WIDTH-1:0] modulation_p2 = 0;
-    logic [OP_OUT_WIDTH+10-1:0] modulation_shifted_p3 = 0;
     logic [PIPELINE_DELAY:1] [$bits(operator_t)-1:0] op_type_p;
+    logic [PIPELINE_DELAY:2] [OP_OUT_WIDTH-1:0] modulation_p;
+    logic [PIPELINE_DELAY:4] [PHASE_FINAL_WIDTH-1:0] final_phase_p;
+    logic [ENV_WIDTH-1:0] env_p4 = 0;
+    logic [OP_OUT_WIDTH-1:0] level_p4;
+    logic [OP_OUT_WIDTH-1:0] level_p5 = 0;
+    logic [EXP_OUT_WIDTH-1:0] exp_out_p5;
+    logic [OP_OUT_WIDTH-1:0] exp_out_post_level_p5;
+    logic [OP_OUT_WIDTH-1:0] neg_p5 = 0;
 
     pipeline_sr #(
         .ENDING_CYCLE(PIPELINE_DELAY)
@@ -138,14 +128,37 @@ module phase_generator
         .ENDING_CYCLE(PIPELINE_DELAY)
     ) op_type_sr (
         .clk,
-        .in(op_type),
+        .in(op_type_p0),
         .out(op_type_p)
+    );
+
+    pipeline_sr #(
+        .DATA_WIDTH(OP_OUT_WIDTH),
+        .STARTING_CYCLE(2),
+        .ENDING_CYCLE(PIPELINE_DELAY)
+    ) modulation_sr (
+        .clk,
+        .in(modulation_p1),
+        .out(modulation_p)
+    );
+
+    pipeline_sr #(
+        .DATA_WIDTH(PHASE_FINAL_WIDTH),
+        .STARTING_CYCLE(4),
+        .ENDING_CYCLE(PIPELINE_DELAY)
+    ) final_phase_sr (
+        .clk,
+        .in(final_phase_p3),
+        .out(final_phase_p)
     );
 
     /*
      * OPL2 only supports first 4 waveforms
      */
-    always_comb ws_post_opl_p0 = ws & (is_new ? 'h7 : 'h3);
+    always_comb begin
+        ws_post_opl_p0 = ws;
+        ws_post_opl_p0[2] = ws[2] && is_new;
+    end
 
     pipeline_sr #(
         .DATA_WIDTH(REG_WS_WIDTH),
@@ -155,11 +168,6 @@ module phase_generator
         .in(ws_post_opl_p0),
         .out(ws_post_opl_p)
     );
-
-    always_ff @(posedge clk) begin
-        env_p4 <= env_p3;
-        env_p5 <= env_p4;
-    end
 
     mem_multi_bank #(
         .DATA_WIDTH(PHASE_ACC_WIDTH),
@@ -180,19 +188,6 @@ module phase_generator
     );
 
     /*
-     * Some rhythm instruments require further transformations to the phase.
-     * Pass through phase_acc[bank_num][op_num] normally.
-     */
-    calc_rhythm_phase calc_rhythm_phase (
-        .*
-    );
-
-    always_ff @(posedge clk) begin
-        modulation_p2 <= modulation_p1;
-        modulation_shifted_p3 <= modulation_p2 << 10;
-    end
-
-    /*
      * Phase Accumulator. Modulation and rhythm get added to the final phase but not
      * back into the accumulator.
      */
@@ -200,135 +195,73 @@ module phase_generator
         if (sample_clk_en_p[2])
             if (key_on_pulse_p[2])
                 phase_acc_p3 <= 0;
-            else if (ws_post_opl_p[2] == 4 || ws_post_opl_p[2] == 5)
-                // double the frequency
-                phase_acc_p3 <= phase_acc_p2 + (phase_inc_p2 << 1);
             else
                 phase_acc_p3 <= phase_acc_p2 + phase_inc_p2;
 
-    always_ff @(posedge clk)
-        if (sample_clk_en_p[3])
-            if (key_on_pulse_p[3])
-                final_phase_p4 <= 0;
-            else
-                final_phase_p4 <= rhythm_phase_p3 + modulation_shifted_p3;
-
-    mem_multi_bank #(
-        .DATA_WIDTH(1),
-        .DEPTH(NUM_OPERATORS_PER_BANK),
-        .OUTPUT_DELAY(2),
-        .DEFAULT_VALUE(0),
-        .NUM_BANKS(NUM_BANKS)
-    ) final_phase_msb_mem (
-        .clk,
-        .wea(sample_clk_en_p[4]),
-        .reb(sample_clk_en),
-        .banka(bank_num_p[4]),
-        .addra(op_num_p[4]),
-        .bankb(bank_num),
-        .addrb(op_num),
-        .dia(final_phase_p4[19]),
-        .dob(prev_final_phase_msb_p2)
-    );
-
-    mem_multi_bank #(
-        .DATA_WIDTH(1),
-        .DEPTH(NUM_OPERATORS_PER_BANK),
-        .OUTPUT_DELAY(2),
-        .DEFAULT_VALUE(0),
-        .NUM_BANKS(NUM_BANKS)
-    ) is_odd_period_msb_mem (
-        .clk,
-        .wea(sample_clk_en_p[5]),
-        .reb(sample_clk_en),
-        .banka(bank_num_p[5]),
-        .addra(op_num_p[5]),
-        .bankb(bank_num),
-        .addrb(op_num),
-        .dia(is_odd_period_p5),
-        .dob(is_odd_period_p2)
-    );
-
-    always_ff @(posedge clk) begin
-        prev_final_phase_msb_p3 <= prev_final_phase_msb_p2;
-        prev_final_phase_msb_p4 <= prev_final_phase_msb_p3;
-        is_odd_period_p3 <= is_odd_period_p2;
-        is_odd_period_p4 <= is_odd_period_p3;
-        is_odd_period_p5 <= prev_final_phase_msb_p4 && !final_phase_p4[19] ? !is_odd_period_p4 : is_odd_period_p4;
-        is_odd_period_p6 <= is_odd_period_p5;
-    end
-
-    opl3_log_sine_lut log_sine_lut_inst (
-        .theta(final_phase_p4[18] ? ~final_phase_p4[17:10]
-         : final_phase_p4[17:10]),
-        .out(log_sin_out_p5),
-    	.*
-    );
-
     /*
-     * Setting the msb effectively mutes. Mute 2nd and 3rd quadrant.
+     * Some rhythm instruments modify the phase, otherwise pass-through normally.
+     * Bottom bits of phase accumulator are fractional and get dropped off.
      */
-    always_ff @(posedge clk) begin
-        unique case (final_phase_p4[19:18])
-        0: tmp_ws7_p5[11] <= 0;
-        1: tmp_ws7_p5[11] <= 1;
-        2: tmp_ws7_p5[11] <= 1;
-        3: tmp_ws7_p5[11] <= 0;
-        endcase
-
-        tmp_ws7_p5[10:0] <= final_phase_p4[19] ? ~final_phase_p4[17:10] << 3 : final_phase_p4[17:10] << 3;
-    end
-
-    always_comb
-        unique case (ws_post_opl_p[5])
-        6: log_sin_plus_gain_p5 = env_p5 << 3;
-        7: log_sin_plus_gain_p5 = tmp_ws7_p5 + (env_p5 << 3);
-        default: log_sin_plus_gain_p5 = log_sin_out_p5 + (env_p5 << 3);
-        endcase
-
-    always_ff @(posedge clk) begin
-        final_phase_p5 <= final_phase_p4;
-        log_sin_plus_gain_p6 <= log_sin_plus_gain_p5;
-    end
-
-    opl3_exp_lut exp_lut_inst (
-        .in(~log_sin_plus_gain_p5[7:0]),
-        .out(exp_out_p6),
+     calc_rhythm_phase calc_rhythm_phase (
+        .phase_p2(phase_acc_p2[PHASE_ACC_WIDTH-1 -: PHASE_FINAL_WIDTH]),
         .*
     );
 
-    always_comb tmp_out0_p6 = (2**10 + exp_out_p6) << 1;
+    always_comb begin
+        final_phase_p3 = rhythm_phase_p3 + modulation_p[3];
 
-    always_comb
-        if (final_phase_p5[19])
-            tmp_out1_p6 = ~(tmp_out0_p6 >> log_sin_plus_gain_p6[LOG_SIN_PLUS_GAIN_WIDTH-1:8]);
-        else
-            tmp_out1_p6 = tmp_out0_p6 >> log_sin_plus_gain_p6[LOG_SIN_PLUS_GAIN_WIDTH-1:8];
+        unique case (ws_post_opl_p[3])
+        0, 1, 2: theta_p3 = final_phase_p3[8] ? final_phase_p3[7:0] ^ 'hff : final_phase_p3[7:0];
+        3:       theta_p3 = final_phase_p3[7:0];
+        4, 5:    theta_p3 = final_phase_p3[7] ? (final_phase_p3[7:0] ^ 'hff) << 1 : final_phase_p3[7:0] << 1;
+        default: theta_p3 = final_phase_p3[7:0]; // 6 and 7 don't use the log_sine_lut
+        endcase
+    end
 
-    always_comb tmp_ws2_p6 = tmp_out1_p6 < 0 ? ~tmp_out1_p6 : tmp_out1_p6;
-    always_comb tmp_ws4_p6 = is_odd_period_p6 ? tmp_out1_p6 : 0;
+    opl3_log_sine_lut log_sine_lut_inst (
+        .theta(theta_p3),
+        .out(log_sin_out_p4),
+    	.*
+    );
 
-    /*
-     * Select waveform, do proper transformations to the wave
-     */
-    always_comb
-        unique case (ws_post_opl_p[6])
-        0: tmp_out2_p6 = tmp_out1_p6;
-        1: tmp_out2_p6 = tmp_out1_p6 < 0 ? 0 : tmp_out1_p6;
-        2: tmp_out2_p6 = tmp_ws2_p6;
-        3: tmp_out2_p6 = final_phase_p5[PHASE_ACC_WIDTH-2] ? 0 : tmp_ws2_p6;
-        4: tmp_out2_p6 = tmp_ws4_p6;
-        5: tmp_out2_p6 = tmp_ws4_p6 < 0 ? ~tmp_ws4_p6 : tmp_ws4_p6;
-        6: tmp_out2_p6 = tmp_out1_p6;
-        7: tmp_out2_p6 = tmp_out1_p6;
+    always_ff @(posedge clk)
+        env_p4 <= env_p3;
+
+    always_comb begin
+        unique case (ws_post_opl_p[4])
+        0, 2:       pre_gain_p4 = log_sin_out_p4;
+        1, 4, 5:    pre_gain_p4 = final_phase_p[4][9] ? 'h1000 : log_sin_out_p4; // setting msb effectively mutes
+        3:          pre_gain_p4 = final_phase_p[4][8] ? 'h1000 : log_sin_out_p4;
+        6:          pre_gain_p4 = 0;
+        7:          pre_gain_p4 = (final_phase_p[4][9] ? (final_phase_p[4][8:0] ^ 'h1ff) : final_phase_p[4][9:0]) << 3;
         endcase
 
-    always_comb
-        unique case (op_type_p[6])
-        OP_NORMAL:    out_p6 = tmp_out2_p6;
-        OP_BASS_DRUM: out_p6 = tmp_out2_p6;
-        default:      out_p6 = tmp_out2_p6 << 1;
+        post_gain_p4 = pre_gain_p4 + (env_p4 << 3);
+        level_p4 = post_gain_p4 > 'h1fff ? 'h1fff : post_gain_p4;
+    end
+
+    opl3_exp_lut exp_lut_inst (
+        .in(~post_gain_p4[7:0]),
+        .out(exp_out_p5),
+        .*
+    );
+
+    always_ff @(posedge clk) begin
+        level_p5 <= level_p4;
+
+        unique case (ws_post_opl_p[4])
+        0, 6, 7: neg_p5 <= final_phase_p[4][9] ? '1 : 0;
+        4:       neg_p5 <= final_phase_p[4][9:8] == 1 ? '1 : 0;
+        default: neg_p5 <= 0;
         endcase
+    end
+
+    always_comb
+        exp_out_post_level_p5 = ((exp_out_p5 | 'h400) << 1) >> (level_p5 >> 8);
+
+    always_ff @(posedge clk)
+        out_p6 <= exp_out_post_level_p5 ^ neg_p5;
+
 endmodule
 `default_nettype wire
 


### PR DESCRIPTION
Rhythm operators were broken. Testcase was Adlib Jukebox, Highways.

Refactored calc_rhythm_phase and phase_generator to match implementation in https://github.com/nukeykt/Nuked-OPL3