### PR TITLE
Drive OPL3 off audio clock, fix SB DSP clock domain crossing

### DIFF
--- a/ao486.sdc
+++ b/ao486.sdc
@@ -4,19 +4,12 @@ derive_clock_uncertainty
 set clk_sys   {*|pll|pll_inst|altera_pll_i|*[0].*|divclk}
 set clk_uart1 {*|pll|pll_inst|altera_pll_i|*[1].*|divclk}
 set clk_mpu   {*|pll|pll_inst|altera_pll_i|*[2].*|divclk}
-set clk_opl   {*|pll|pll_inst|altera_pll_i|*[3].*|divclk}
 set clk_audio {pll_audio|pll_audio_inst|altera_pll_i|*[0].*|divclk}
 set clk_vga   {*|pll|pll_inst|altera_pll_i|*[4].*|divclk}
 set clk_uart2 {*|pll|pll_inst|altera_pll_i|*[5].*|divclk}
 
 set_false_path -from [get_clocks $clk_sys]   -to [get_clocks $clk_vga]
 set_false_path -from [get_clocks $clk_vga]   -to [get_clocks $clk_sys]
-
-set_false_path -from [get_clocks $clk_sys]   -to [get_clocks $clk_opl]
-set_false_path -from [get_clocks $clk_opl]   -to [get_clocks $clk_sys]
-
-set_false_path -from [get_clocks $clk_opl]   -to [get_clocks $clk_audio]
-set_false_path -from [get_clocks $clk_audio] -to [get_clocks $clk_opl]
 
 set_false_path -from [get_clocks $clk_audio] -to [get_clocks $clk_sys]
 set_false_path -from [get_clocks $clk_sys]   -to [get_clocks $clk_audio]

--- a/ao486.sv
+++ b/ao486.sv
@@ -376,7 +376,7 @@ hps_ext hps_ext
 
 /////////////////////////////  PLL  ////////////////////////////////////
 
-wire clk_sys, clk_uart1, clk_uart2, clk_mpu, clk_opl, clk_vga;
+wire clk_sys, clk_uart1, clk_uart2, clk_mpu, clk_vga;
 reg [27:0] cur_rate;
 
 `ifdef DEBUG
@@ -387,7 +387,7 @@ pll2 pll
 	.outclk_0(clk_vga),
 	.outclk_1(clk_uart1),
 	.outclk_2(clk_mpu),
-	.outclk_3(clk_opl),
+	.outclk_3(),
 	.outclk_4(clk_sys),
 	.outclk_5(clk_uart2)
 );
@@ -405,7 +405,7 @@ pll pll
 	.outclk_0(clk_sys),
 	.outclk_1(clk_uart1),
 	.outclk_2(clk_mpu),
-	.outclk_3(clk_opl), // 14.285714 instead of 14.318181 which is within tolerance of typical resonator
+	.outclk_3(), // 14.285714 instead of 14.318181 which is within tolerance of typical resonator
 	.outclk_4(clk_vga),
 	.outclk_5(clk_uart2),
 	.locked(pll_locked),
@@ -742,8 +742,7 @@ wire [4:0] vol_en;
 system system
 (
 	.clk_sys              (clk_sys),
-	.clk_opl              (clk_opl),
-	.CLK_AUDIO            (CLK_AUDIO),
+	.clk_audio            (CLK_AUDIO),
 	.clk_uart1            (clk_uart1),
 	.clk_uart2            (clk_uart2),
 	.clk_mpu              (clk_mpu),

--- a/ao486.sv
+++ b/ao486.sv
@@ -1012,19 +1012,54 @@ always @(posedge CLK_AUDIO) begin
 	spk_out <= spk >> ~vol_spk;
 end
 
+// cross clk_host->clk_audio domains using single bit synchronized handshaking signal
+// 100e6/24.576e6 * 2 + 1 = hold signals stable for 9 cycles to pass through synchronizer
 wire [15:0] sb_out_l, sb_out_r;
+reg [15:0] sb_out_l_p1, sb_out_r_p1, sb_out_l_hold, sb_out_r_hold;
+reg new_sample_l_clk_sys, new_sample_r_clk_sys;
+reg [8:0] new_sample_l_hold_sr, new_sample_r_hold_sr;
+reg new_sample_l_clk_audio_p0, new_sample_r_clk_audio_p0, new_sample_l_clk_audio_p1, new_sample_r_clk_audio_p1;
 wire [16:0] sb_l, sb_r;
-always @(posedge CLK_AUDIO) begin
-	reg [15:0] old_l0, old_l1, old_r0, old_r1;
 
-	old_l0 <= sb_out_l;
-	old_l1 <= old_l0;
-	if(old_l0 == old_l1) sb_l <= {old_l1[15],old_l1};
+always @(posedge clk_sys) begin
+	sb_out_l_p1 <= sb_out_l;
+	sb_out_r_p1 <= sb_out_r;
 
-	old_r0 <= sb_out_r;
-	old_r1 <= old_r0;
-	if(old_r0 == old_r1) sb_r <= {old_r1[15],old_r1};
+	new_sample_l_hold_sr <= new_sample_l_hold_sr << 1;
+	new_sample_r_hold_sr <= new_sample_r_hold_sr << 1;
+
+	if (new_sample_l_hold_sr == 0)
+		new_sample_l_clk_sys <= 0;
+
+	if (new_sample_r_hold_sr == 0)
+		new_sample_r_clk_sys <= 0;
+
+	if (sb_out_l != sb_out_l_p1 && new_sample_l_hold_sr == 0) begin
+		new_sample_l_clk_sys <= 1;
+		new_sample_l_hold_sr[0] <= 1;
+		sb_out_l_hold <= sb_out_l;
 	end
+
+	if (sb_out_r != sb_out_r_p1 && new_sample_r_hold_sr == 0) begin
+		new_sample_r_clk_sys <= 1;
+		new_sample_r_hold_sr[0] <= 1;
+		sb_out_r_hold <= sb_out_r;
+	end
+end
+
+always @(posedge CLK_AUDIO) begin
+	new_sample_l_clk_audio_p0 <= new_sample_l_clk_sys;
+	new_sample_l_clk_audio_p1 <= new_sample_l_clk_audio_p0;
+
+	new_sample_r_clk_audio_p0 <= new_sample_r_clk_sys;
+	new_sample_r_clk_audio_p1 <= new_sample_r_clk_audio_p0;
+
+	if (new_sample_l_clk_audio_p1)
+		sb_l <= {sb_out_l_hold[15],sb_out_l_hold};
+
+	if (new_sample_r_clk_audio_p1)
+		sb_r <= {sb_out_r_hold[15],sb_out_r_hold};
+end
 
 wire [15:0] opl_out_l, opl_out_r; // already synced to CLK_AUDIO
 

--- a/rtl/soc/sound/opl3/env_rate_counter.sv
+++ b/rtl/soc/sound/opl3/env_rate_counter.sv
@@ -74,7 +74,6 @@ module env_rate_counter
     logic [PIPELINE_DELAY:1] sample_clk_en_p;
     logic [PIPELINE_DELAY:1] [BANK_NUM_WIDTH-1:0] bank_num_p;
     logic [PIPELINE_DELAY:1] [OP_NUM_WIDTH-1:0] op_num_p;
-    logic key_on_pulse_p1 = 0;
 
     pipeline_sr #(
         .ENDING_CYCLE(PIPELINE_DELAY)

--- a/rtl/soc/sound/opl3/opl3_pkg.sv
+++ b/rtl/soc/sound/opl3/opl3_pkg.sv
@@ -41,14 +41,14 @@
 #
 #******************************************************************************/
 package opl3_pkg;
-    localparam CLK_FREQ = 14.318181e6; // original OPL3 clk rate
+    localparam CLK_FREQ = 24.576e6;
     localparam DAC_OUTPUT_WIDTH = 16;
     localparam INSTANTIATE_TIMERS = 1; // set to 1 to use timers, 0 to save area
     localparam NUM_LEDS = 0; // connected to kon bank 0 starting at 0
-    localparam INSTANTIATE_SAMPLE_SYNC_TO_DAC_CLK = 1;
+    localparam INSTANTIATE_SAMPLE_SYNC_TO_DAC_CLK = 0;
 
     localparam DESIRED_SAMPLE_FREQ = 49.7159e3;
-    localparam int CLK_DIV_COUNT = 288;
+    localparam int CLK_DIV_COUNT = 494; // gets us to 49.74899KHz sample freq, +0.07% away
     localparam ACTUAL_SAMPLE_FREQ = CLK_FREQ/CLK_DIV_COUNT;
 
     localparam NUM_REG_PER_BANK = 'hF6;

--- a/rtl/soc/sound/sound.v
+++ b/rtl/soc/sound/sound.v
@@ -355,7 +355,7 @@ always @(posedge clk) begin
 	sample_dsp_r <= volume(dsp_value_r, vol_vo_r);
 end
 
-always @(posedge CLK_AUDIO) begin // vol reg expected to be held for a long time, clk domain crossing not a big deal
+always @(posedge clk_audio) begin // vol reg expected to be held for a long time, clk domain crossing not a big deal
 	sample_opl_l <= volume(sample_from_opl_l, vol_mi_l);
 	sample_opl_r <= volume(sample_from_opl_r, vol_mi_r);
 end

--- a/rtl/soc/sound/sound.v
+++ b/rtl/soc/sound/sound.v
@@ -28,8 +28,7 @@
 module sound
 (
 	input             clk,
-	input             clk_opl,
-	input			  CLK_AUDIO,
+	input			  clk_audio,
 	input             rst_n,
 
 	output            irq_5,
@@ -159,9 +158,9 @@ wire opl_rd = read;
 
 opl3 opl
 (
-    .clk(clk_opl),
+    .clk(clk_audio),
     .clk_host(clk),
-	.clk_dac(CLK_AUDIO),
+	.clk_dac(),
     .ic_n(rst_n),
     .cs_n(!opl_cs),
     .rd_n(!opl_rd),

--- a/rtl/system.v
+++ b/rtl/system.v
@@ -63,8 +63,7 @@ module system
 	input         mpu_rx,
 	output        mpu_tx,
 
-	input         clk_opl,
-	input         CLK_AUDIO,
+	input         clk_audio,
 	output [15:0] sample_sb_l,
 	output [15:0] sample_sb_r,
 	output [15:0] sample_opl_l,
@@ -634,8 +633,7 @@ rtc rtc
 sound sound
 (
 	.clk               (clk_sys),
-	.clk_opl           (clk_opl),
-	.CLK_AUDIO         (CLK_AUDIO),
+	.clk_audio         (clk_audio),
 	.rst_n             (~reset),
 
 	.clock_rate        (clock_rate),


### PR DESCRIPTION
Use clk_audio to drive OPL3 as this is what the final clock domain is anyway (removes clk_opl entirely for better overall stability as discussed with @sorgelig here https://github.com/MiSTer-devel/ao486_MiSTer/pull/157), and we already have an existing sample clock enable implemented. Using divider of 494 gets us to 49.74899KHz sample freq, +0.07% away from perfect, closer than we were after removal of OPL3 PLL.

Also fixed the SB DSP & CMS clock domain crossing from clk_sys->clk_audio. Possible reduction in noise.