### PR TITLE
Reset new and connection_sel regs specific to OPL3

### DIFF
--- a/rtl/soc/sound/opl3/channels.sv
+++ b/rtl/soc/sound/opl3/channels.sv
@@ -75,7 +75,7 @@ module channels
     logic cnt; // operator connection
     logic [REG_FB_WIDTH-1:0] fb_dummy;
 
-    always_ff @(posedge clk)
+    always_ff @(posedge clk) begin
         if (opl3_reg_wr.valid) begin
             if (opl3_reg_wr.bank_num == 1 && opl3_reg_wr.address == 4)
                 connection_sel <= opl3_reg_wr.data[REG_CONNECTION_SEL_WIDTH-1:0];
@@ -86,6 +86,13 @@ module channels
             if (opl3_reg_wr.bank_num == 0 && opl3_reg_wr.address == 'hBD)
                 ryt <= opl3_reg_wr.data[5];
         end
+
+        if (reset) begin
+            // these should be reset as next game after reset may be OPL2 and not clear bank 1
+            connection_sel <= 0;
+            is_new <= 0;
+        end
+    end
 
     mem_multi_bank #(
         .DATA_WIDTH(REG_FILE_DATA_WIDTH),


### PR DESCRIPTION
Games will typically clear both banks on start and exit. However, if a reset occurs during a game that is using OPL3 features and sets `new` and `connection_sel` regs in the second bank, the next game may be OPL2-only and not clear the second bank as it didn't exist on the OPL2.

Not resetting the other regs in the second bank is fine as the envelope for all operators gets reset to the RELEASE state.

I found this bug today showing someone the ao486, resetting in the middle of Doom (with DMXOPTION=-opl3-phase) and launching Indiana Jones and the Fate of Atlantis. There was no music in Indiana Jones as the `new` bit was still set and if it is at least one `cha`, `chb`, `chc`, or `chd` reg must be set for the channels to get added to the accumulator, and these regs would have gotten cleared at launch of the game.
