### PR TITLE
Prefetch: Fix prefetch reset

### DIFF
--- a/rtl/ao486/memory/prefetch.v
+++ b/rtl/ao486/memory/prefetch.v
@@ -102,7 +102,7 @@ always @(posedge clk) begin
       linear        <= cs_base + prefetch_eip; 
       delivered_eip <= cs_base + prefetch_eip;
     end else begin
-      if(reset_prefetch)         linear <= delivered_eip;
+      if(reset_prefetch)         linear <= prefetched_accept_do_1 ? delivered_eip + prefetched_accept_length_1 : delivered_eip;
       else if(prefetched_do)     linear <= linear + { 27'd0, length };
       
       if(prefetched_accept_do_1) delivered_eip <= delivered_eip + prefetched_accept_length_1;


### PR DESCRIPTION
When a prefetch reset is triggered under certain conditions (in the middle of `prefetchfifo_accept_do`), the decoder can still fetch instruction bytes and will load the same bytes twice.

The bug can be replicated using the following code (compile a .COM file using e.g. NASM):
(the `C7` `MOV` instruction is where things go wrong)

`MOV_BAD.ASM`
```
org     100h
use16

nop
nop
nop
nop
nop
nop
mov     byte [cs:var_b1], 0x8
nop
inc     si
mov     word [cs:var_w1], 0xa8      ; reset_prefetch triggered here by icache
mov     word [cs:var_w2], 0xa8      ; but linear not updated correctly by prefetch
nop
nop
nop
nop
nop

jmp exit

var_b1: db 0bh
var_b2: db 0fh
var_w1: dw 01234h
var_w2: dw 0abcdh

exit:
mov ax,4C00h
int 21h

mov ax, [cs:var_b1]
mov bx, [cs:var_w1]
mov cx, [cs:var_w2]

jmp 100h
```

Note that the `nop`'s are important for the timing! When removing the first nop, the bug will not be triggered.

Affected games:
- Pinball Fantasies (matrix left to right scrolling crash)
- others...