### PR TITLE
VGA: Add border support and various fixes

### DIFF
--- a/rtl/system.v
+++ b/rtl/system.v
@@ -106,6 +106,7 @@ module system
 	output        video_off,
 	input         video_fb_en,
 	input         video_lores,
+	input         video_border,
 
 	output        DDRAM_CLK,
 	input         DDRAM_BUSY,
@@ -790,6 +791,7 @@ vga vga
 	.vga_stride        (video_stride),
 	.vga_off           (video_off),
 	.vga_lores         (video_lores),
+	.vga_border        (video_border),
 
 	.irq               (irq_2)
 );


### PR DESCRIPTION
Biggest changes:
- Add border support (overscan).
- Graceful handling of odd number of overscan lines for Native mode.
- More accurate VGA timing signals.
- Added `attrib_mono_emulation` handling (MDA/Hercules emulation in mode 7).
- Reduce timing violations.
- Refactoring.

Fixes:
- Pinball Fantasies (startup delay)
- Pinball Dreams (black screen)
- #119
- #126
- Prehistorik 2 (scrolling)
- The Incredible Machine (black screen)
- Alien Carnage (flashing screen)
- others...