### PR TITLE
Microcode: Fix TSS task switching (fixes e.g. DOS4GW, DJGPP, CWSDPMI)

### DIFF
--- a/rtl/ao486/autogen/microcode_commands.v
+++ b/rtl/ao486/autogen/microcode_commands.v
@@ -203,7 +203,7 @@ wire cond_200 = mc_cmd == `CMD_task_switch && mc_cmdex_last == `CMDEX_task_switc
 wire cond_201 = mc_cmd == `CMD_task_switch && mc_cmdex_last == `CMDEX_task_switch_STEP_12;
 wire cond_202 = mc_cmd == `CMD_task_switch && mc_cmdex_last == `CMDEX_task_switch_STEP_13;
 wire cond_203 = mc_cmd == `CMD_task_switch && mc_cmdex_last == `CMDEX_task_switch_STEP_14;
-wire cond_204 = mc_cmd == `CMD_task_switch_3;
+wire cond_204 = mc_cmd == `CMD_task_switch_3 && mc_cmdex_last < `CMDEX_task_switch_3_STEP_15;
 wire cond_205 = mc_cmd == `CMD_task_switch_3 && mc_cmdex_last == `CMDEX_task_switch_3_STEP_15;
 wire cond_206 = mc_cmd == `CMD_task_switch_4 && mc_cmdex_last < `CMDEX_task_switch_4_STEP_10;
 wire cond_207 = mc_cmd == `CMD_SGDT || mc_cmd == `CMD_SIDT;

--- a/rtl/ao486/commands/CMD_task_switch.txt
+++ b/rtl/ao486/commands/CMD_task_switch.txt
@@ -129,7 +129,7 @@ IF(`CMDEX_task_switch_STEP_9);
     ENDIF();
 ENDIF();
 
-IF(mc_cmd == `CMD_task_switch_3);
+IF(mc_cmd == `CMD_task_switch_3 && mc_cmdex_last < `CMDEX_task_switch_3_STEP_15);
     DIRECT(mc_cmd, mc_cmdex_last + 4'd1);
 ENDIF();
 


### PR DESCRIPTION
During TSS task switching, when reaching the step `CMDEX_task_switch_3_STEP_15`, it doesn't progress to `CMD_task_switch_4`, but hangs in `CMD_task_switch_3` (command `cond_204` stays active).

This has the effect of reading more memory until a page fault occurs. The task switch does not happen.

This fixes hangcrashes with e.g. DOS4GW, DJGPP, CWSDPMI, SoftICE and should at least also fix #128 and #39.

It also seems to reveal new issues with Windows 95.