### PR TITLE
CPUID: GenuineIntel

### DIFF
--- a/rtl/ao486/autogen/write_commands.v
+++ b/rtl/ao486/autogen/write_commands.v
@@ -189,7 +189,7 @@ wire cond_162 = wr_cmd == `CMD_INT_INTO && wr_cmdex == `CMDEX_INT_INTO_INTO_STEP
 wire cond_163 = oflag;
 wire cond_164 = wr_cmd == `CMD_CPUID;
 wire cond_165 = eax == 32'd0;
-wire cond_166 = eax != 32'd0;
+wire cond_166 = eax == 32'd1;
 wire cond_167 = wr_cmd == `CMD_IN;
 wire cond_168 = ~(io_allow_check_needed) || wr_cmdex == `CMDEX_IN_protected;
 wire cond_169 = wr_cmd == `CMD_NOT;
@@ -298,6 +298,7 @@ wire cond_271 = wr_cmd == `CMD_XLAT;
 wire cond_272 = wr_cmd == `CMD_AAA || wr_cmd == `CMD_AAS;
 wire cond_273 = wr_cmd == `CMD_DAA || wr_cmd == `CMD_DAS;
 wire cond_274 = { wr_cmd[6:1], 1'd0 } == `CMD_BSx;
+wire cond_275 = eax > 32'd1;
 //======================================================== saves
 assign gdtr_limit_to_reg =
     (cond_119 && cond_121 && cond_120)? ( result2[15:0]) :
@@ -448,8 +449,9 @@ assign ss_to_reg =
     (cond_240)? (                task_ss) :
     ss;
 assign ebx_to_reg =
-    (cond_164 && cond_165)? ( "TSiM") :
+    (cond_164 && cond_165)? ( "uneG") :
     (cond_164 && cond_166)? ( 32'h00010000) :
+    (cond_164 && cond_275)? ( 32'd0) :
     (cond_240)? ( (glob_descriptor[`DESC_BITS_TYPE] <= 4'd3)? { 16'hFFFF, exe_buffer_shifted[255:240] } : exe_buffer_shifted[271:240]) :
     (cond_263 && cond_264)? ( { wr_operand_16bit? ebx[31:16] : exe_buffer_shifted[95:80],   exe_buffer_shifted[79:64] }) :
     ebx;
@@ -562,6 +564,7 @@ assign eax_to_reg =
     (cond_155)? ( (wr_operand_16bit)? { eax[31:16], result2[15:0] } : result2) :
     (cond_164 && cond_165)? ( 32'd1) :
     (cond_164 && cond_166)? ( `CPUID_MODEL_FAMILY_STEPPING) :
+    (cond_164 && cond_275)? ( 32'd0) :
     (cond_167 && cond_168)? ( (wr_is_8bit)? { eax[31:8], result2[7:0] } : (wr_operand_16bit)? { eax[31:16], result2[15:0] } : result2) :
     (cond_213)? ( { eax[31:16], sflag, zflag, 1'b0, aflag, 1'b0, pflag, 1'b1, cflag, eax[7:0] }) :
     (cond_214 && cond_83)? ( { {16{eax[15]}}, eax[15:0] }) :
@@ -657,8 +660,9 @@ assign edx_to_reg =
     (cond_100 && cond_101)? ( (wr_operand_16bit)? { edx[31:16], result[31:16] } : result2) :
     (cond_133 && cond_134 && cond_101)? ( (wr_operand_16bit)? { edx[31:16], result[31:16] } : result2) :
     (cond_142 && cond_134 && cond_101)? ( (wr_operand_16bit)? { edx[31:16], result[31:16] } : result2) :
-    (cond_164 && cond_165)? ( "A re") :
+    (cond_164 && cond_165)? ( "Ieni") :
     (cond_164 && cond_166)? ( 32'd0) :
+    (cond_164 && cond_275)? ( 32'd0) :
     (cond_215 && cond_83)? ( {32{eax[31]}}) :
     (cond_215 && ~cond_83)? ( { edx[31:16], {16{eax[15]}} }) :
     (cond_240)? ( (glob_descriptor[`DESC_BITS_TYPE] <= 4'd3)? { 16'hFFFF, exe_buffer_shifted[287:272] } : exe_buffer_shifted[303:272]) :
@@ -776,8 +780,9 @@ assign ecx_to_reg =
     (cond_143 && cond_144)? ( { ecx[31:16], wr_ecx_minus_1[15:0] }) :
     (cond_143 && ~cond_144)? ( wr_ecx_minus_1) :
     (cond_152 && cond_33 && cond_34)? ( wr_ecx_final) :
-    (cond_164 && cond_165)? ( "684O") :
+    (cond_164 && cond_165)? ( "letn") :
     (cond_164 && cond_166)? ( 32'd0) :
+    (cond_164 && cond_275)? ( 32'd0) :
     (cond_192 && cond_33 && ~cond_9 && cond_34)? ( wr_ecx_final) :
     (cond_196 && ~cond_197 && cond_33 && ~cond_9 && cond_34)? ( wr_ecx_final) :
     (cond_199 && ~cond_200 && cond_33 && ~cond_201 && cond_34)? ( wr_ecx_final) :

--- a/rtl/ao486/commands/CMD_CPUID.txt
+++ b/rtl/ao486/commands/CMD_CPUID.txt
@@ -24,7 +24,7 @@ IF(rd_cmd == `CMD_CPUID);
     SET(rd_req_ebx);
     SET(rd_req_ecx);
     SET(rd_req_edx);
-
+    
     IF(rd_mutex_busy_eax); SET(rd_waiting); ENDIF();
 ENDIF();
 </read>
@@ -34,14 +34,21 @@ IF(wr_cmd == `CMD_CPUID);
     
     IF(eax == 32'd0);
         SAVE(eax, 32'd1);
-        SAVE(ebx, "TSiM");
-        SAVE(edx, "A re");
-        SAVE(ecx, "684O");
+        SAVE(ebx, "uneG");
+        SAVE(edx, "Ieni");
+        SAVE(ecx, "letn");
     ENDIF();
     
-    IF(eax != 32'd0);
+    IF(eax == 32'd1);
         SAVE(eax, `CPUID_MODEL_FAMILY_STEPPING);
         SAVE(ebx, 32'h00010000);
+        SAVE(ecx, 32'd0);
+        SAVE(edx, 32'd0);
+    ENDIF();
+    
+    IF(eax > 32'd1);
+        SAVE(eax, 32'd0);
+        SAVE(ebx, 32'd0);
         SAVE(ecx, 32'd0);
         SAVE(edx, 32'd0);
     ENDIF();
@@ -52,4 +59,3 @@ IF(wr_cmd == `CMD_CPUID);
     SET(wr_req_reset_exe);
 ENDIF();  
 </write>
-


### PR DESCRIPTION
Change the CPU's manufacturer ID string returned by CPUID (EAX=0) from "MiSTer AO486" to "GenuineIntel" to help improve compatibility.

Fixes:
- Memtest86+ v4.10

See also a forum discussion about this [here](https://misterfpga.org/viewtopic.php?t=6582).