### PR TITLE
CPUID: Return EBX=0 for leaf 1

### DIFF
--- a/rtl/ao486/autogen/write_commands.v
+++ b/rtl/ao486/autogen/write_commands.v
@@ -450,7 +450,7 @@ assign ss_to_reg =
     ss;
 assign ebx_to_reg =
     (cond_164 && cond_165)? ( "uneG") :
-    (cond_164 && cond_166)? ( 32'h00010000) :
+    (cond_164 && cond_166)? ( 32'h0) :
     (cond_164 && cond_275)? ( 32'd0) :
     (cond_240)? ( (glob_descriptor[`DESC_BITS_TYPE] <= 4'd3)? { 16'hFFFF, exe_buffer_shifted[255:240] } : exe_buffer_shifted[271:240]) :
     (cond_263 && cond_264)? ( { wr_operand_16bit? ebx[31:16] : exe_buffer_shifted[95:80],   exe_buffer_shifted[79:64] }) :

--- a/rtl/ao486/commands/CMD_CPUID.txt
+++ b/rtl/ao486/commands/CMD_CPUID.txt
@@ -41,7 +41,7 @@ IF(wr_cmd == `CMD_CPUID);
     
     IF(eax == 32'd1);
         SAVE(eax, `CPUID_MODEL_FAMILY_STEPPING);
-        SAVE(ebx, 32'h00010000);
+        SAVE(ebx, 32'h0);
         SAVE(ecx, 32'd0);
         SAVE(edx, 32'd0);
     ENDIF();


### PR DESCRIPTION
According to AP-485 version 241618-004 "Intel Processor Identification With the CPUID Instruction" from December 1995 (e.g. the A80486SX2-50 was released in 1995) the `EBX` and `ECX` registers are Intel reserved for the CPUID leaf 1 and should not be used.

The CPUID leaf 1 should probably return `EBX=0` for a 486SX2-50.

Only later (introduced in the Pentium processor?) the CPUID leaf 1 returned additional information in the `EBX` register:
- `EBX[7:0]` = Brand index
- `EBX[15:8]` = CLFLUSH instruction cache line size
- `EBX[23:16]` = Logical CPU (HW threads) count
- `EBX[31:24]` = Initial local APIC physical ID