### PR TITLE
Microcode: Merge TSS fix

### DIFF
--- a/ao486.sv
+++ b/ao486.sv
@@ -195,7 +195,7 @@ led fdd_led(clk_sys, |mgmt_req[7:6], LED_USER);
 // 0         1         2         3          4         5         6
 // 01234567890123456789012345678901 23456789012345678901234567890123
 // 0123456789ABCDEFGHIJKLMNOPQRSTUV 0123456789ABCDEFGHIJKLMNOPQRSTUV
-// XXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXX XXXXXXXXXXXXXXXXXXXXXXXXX
+// XXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXX XXXXXXXXXXXXXXXXXXXXXXXX
 
 `include "build_id.v"
 localparam CONF_STR =
@@ -247,8 +247,6 @@ localparam CONF_STR =
 	"H5D2P2OG,L2 Cache,On,Off;",
 `endif
 	"P2-;",
-	"P2oO,TSS Fix,Off,On;",
-	"P2-;",
 	"P2OA,USER I/O,MIDI,COM2;",
 	"P2-;",
 	"P2OCD,Joystick type,2 Buttons,4 Buttons,Gravis Pro,None;",
@@ -267,7 +265,7 @@ localparam CONF_STR =
 	"h3P3OTV,SoundFont,0,1,2,3,4,5,6,7;",
 	"h3P3-;",
 	"h3P3r8,Reset Hanging Notes;",
-	"- ;",
+	"-;",
 	"R0,Reset and apply HDD;",
 	"J,Button 1,Button 2,Button 3,Button 4,Start,Select,R1,L1,R2,L2;",
 	"jn,A,B,X,Y,Start,Select,R,L;",
@@ -742,7 +740,6 @@ system system
 	.syscfg               (syscfg),
 	.l1_disable           (l1),
 	.l2_disable           (l2),
-	.tss_fix              (status[56]), // Fixes TSS task switching but introduces issues in Win95. Needs further fix, so currently it's an optional. 
 
 	.video_ce             (vga_ce),
 	.video_f60            (~status[4] | f60),

--- a/rtl/ao486/ao486.v
+++ b/rtl/ao486/ao486.v
@@ -33,7 +33,6 @@ module ao486 (
 	input               a20_enable,
 	
 	input               cache_disable,
-	input               tss_fix,
 
 	//--------------------------------------------------------------------------
 	input               interrupt_do,
@@ -548,10 +547,9 @@ pipeline pipeline_inst(
     .rd_reset                      (rd_reset),                      //output
     .exe_reset                     (exe_reset),                     //output
     .wr_reset                      (wr_reset),                      //output
-                       
+    
     .real_mode                     (real_mode),                     //output
-    .tss_fix                       (tss_fix),
-
+    
     //exception
     .exc_restore_esp               (exc_restore_esp),               //input
     .exc_set_rflag                 (exc_set_rflag),                 //input

--- a/rtl/ao486/autogen/microcode_commands.v
+++ b/rtl/ao486/autogen/microcode_commands.v
@@ -203,7 +203,7 @@ wire cond_200 = mc_cmd == `CMD_task_switch && mc_cmdex_last == `CMDEX_task_switc
 wire cond_201 = mc_cmd == `CMD_task_switch && mc_cmdex_last == `CMDEX_task_switch_STEP_12;
 wire cond_202 = mc_cmd == `CMD_task_switch && mc_cmdex_last == `CMDEX_task_switch_STEP_13;
 wire cond_203 = mc_cmd == `CMD_task_switch && mc_cmdex_last == `CMDEX_task_switch_STEP_14;
-wire cond_204 = mc_cmd == `CMD_task_switch_3 && (!tss_fix || (mc_cmdex_last < `CMDEX_task_switch_3_STEP_15));
+wire cond_204 = mc_cmd == `CMD_task_switch_3 && mc_cmdex_last < `CMDEX_task_switch_3_STEP_15;
 wire cond_205 = mc_cmd == `CMD_task_switch_3 && mc_cmdex_last == `CMDEX_task_switch_3_STEP_15;
 wire cond_206 = mc_cmd == `CMD_task_switch_4 && mc_cmdex_last < `CMDEX_task_switch_4_STEP_10;
 wire cond_207 = mc_cmd == `CMD_SGDT || mc_cmd == `CMD_SIDT;

--- a/rtl/ao486/pipeline/microcode.v
+++ b/rtl/ao486/pipeline/microcode.v
@@ -42,7 +42,6 @@ module microcode(
     input               real_mode,
     input               v8086_mode,
     input               protected_mode,
-    input               tss_fix,
     
     input               io_allow_check_needed,
     input               exc_push_error,
@@ -146,7 +145,6 @@ microcode_commands microcode_commands_inst(
     .protected_mode         (protected_mode),    //input
     .real_mode              (real_mode),         //input
     .v8086_mode             (v8086_mode),        //input
-    .tss_fix                (tss_fix),
     
     .io_allow_check_needed  (io_allow_check_needed), //input
     .exc_push_error         (exc_push_error),        //input

--- a/rtl/ao486/pipeline/microcode_commands.v
+++ b/rtl/ao486/pipeline/microcode_commands.v
@@ -35,7 +35,6 @@ module microcode_commands(
     input               protected_mode,
     input               real_mode,
     input               v8086_mode,
-    input               tss_fix,
     
     input               io_allow_check_needed,
     input               exc_push_error,

--- a/rtl/ao486/pipeline/pipeline.v
+++ b/rtl/ao486/pipeline/pipeline.v
@@ -37,7 +37,6 @@ module pipeline(
     output              wr_reset,
     
     output              real_mode,
-    input               tss_fix,
     
     //exception
     input               exc_restore_esp,
@@ -593,7 +592,6 @@ microcode microcode_inst(
     .real_mode                     (real_mode),                     //input
     .v8086_mode                    (v8086_mode),                    //input
     .protected_mode                (protected_mode),                //input
-    .tss_fix                       (tss_fix),
     
     .io_allow_check_needed         (io_allow_check_needed),         //input
     .exc_push_error                (exc_push_error),                //input

--- a/rtl/system.v
+++ b/rtl/system.v
@@ -8,7 +8,6 @@ module system
 
 	input         l1_disable,
 	input         l2_disable,
-	input         tss_fix,
 
 	output [1:0]  fdd_request,
 	output [2:0]  ide0_request,
@@ -279,7 +278,6 @@ ao486 ao486
 	.rst_n             (~reset),
 
 	.cache_disable     (l1_disable),
-	.tss_fix           (tss_fix),
 
 	.avm_address       (mem_address),
 	.avm_writedata     (mem_writedata),


### PR DESCRIPTION
It seems that the Windows 95 issues I noticed with the "TSS Fix" resulted from an issue with my setup.

After some updates and exhaustive testing I cannot seem to reproduce the Windows 95 issues anymore (tested multiple Windows 95 VHD disk images and a fresh Windows 95 OSR2 installation).

Maybe it was the result of a combination of a bad ao486 build and/or SD card corruption after too much abusive testing?

Unless anyone notices consistent errors in Windows 95 with the ao486_20241227 core with "TSS Fix" enabled it is probably safe to make the "TSS Fix" permanent and remove the associated menu option.

If anyone wants to help rule out possible issues, please test Windows 95 with the "TSS Fix" option enabled and report any recurring and reproducible BSOD issues.