### PR TITLE
Add D0000h-EFFFFh RAM option

### DIFF
--- a/ao486.sv
+++ b/ao486.sv
@@ -195,7 +195,7 @@ led fdd_led(clk_sys, |mgmt_req[7:6], LED_USER);
 // 0         1         2         3          4         5         6
 // 01234567890123456789012345678901 23456789012345678901234567890123
 // 0123456789ABCDEFGHIJKLMNOPQRSTUV 0123456789ABCDEFGHIJKLMNOPQRSTUV
-// XXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXX XXXXXXXXXXXXXXXXXXXXXXXXX
+// XXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXX XXXXXXXXXXXXXXXXXXXXXXXXXX
 
 `include "build_id.v"
 localparam CONF_STR =
@@ -239,6 +239,7 @@ localparam CONF_STR =
 	"P2o7,IDE 1-1 CD Hot-Swap,No,Yes;",
 	"P2-;",
 	"P2OB,RAM Size,256MB,16MB;",
+	"P2oP,D0000h-EFFFFh RAM,Off,On;",
 `ifndef DEBUG
 	"H5P2-;",
 	"H5D2D1P2O56,CPU Clock,90MHz,15MHz,30MHz,56MHz;",
@@ -835,6 +836,7 @@ system system
 	.mpu_tx               (mpu_tx),
 
 	.memcfg               (memcfg),
+	.uma_ram              (status[57]),
 	.bootcfg              (status[37:32]),
 
 	.DDRAM_CLK            (DDRAM_CLK),

--- a/rtl/system.v
+++ b/rtl/system.v
@@ -40,6 +40,7 @@ module system
 
 	input   [5:0] bootcfg,
 	input         memcfg,
+	input         uma_ram,
 	output  [7:0] syscfg,
 
 	input         clk_uart1,
@@ -270,7 +271,9 @@ l2_cache cache
 
 	.VGA_WR_SEG        (video_wr_seg),
 	.VGA_RD_SEG        (video_rd_seg),
-	.VGA_FB_EN         (video_fb_en)
+	.VGA_FB_EN         (video_fb_en),
+
+	.uma_ram           (uma_ram)
 );
 
 ao486 ao486


### PR DESCRIPTION
Adds a menu option to enable RAM in the upper memory region D0000h-EFFFFh.

Use this option with e.g. HiRAM.

Fixes: #177