### PR TITLE
Joystick: Fix bugs, add axes options (Timed/Count), and refactor code

### DIFF
--- a/ao486.sv
+++ b/ao486.sv
@@ -195,7 +195,7 @@ led fdd_led(clk_sys, |mgmt_req[7:6], LED_USER);
 // 0         1         2         3          4         5         6
 // 01234567890123456789012345678901 23456789012345678901234567890123
 // 0123456789ABCDEFGHIJKLMNOPQRSTUV 0123456789ABCDEFGHIJKLMNOPQRSTUV
-// XXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXX XXXXXXXXXXXXXXXXXXXXXXXX X
+// XXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXX XXXXXXXXXXXXXXXXXXXXXXXX XXX
 
 `include "build_id.v"
 localparam CONF_STR =
@@ -252,6 +252,7 @@ localparam CONF_STR =
 	"P2-;",
 	"P2OCD,Joystick type,2 Buttons,4 Buttons,Gravis Pro,None;",
 	"P2oFG,Joystick Mode,2 Joysticks,2 Sticks,2 Wheels,4-axes Wheel;",
+	"P2oQR,Joystick Axes,Timed,Count 8+141,Count 0+256,Count 6+256;",
 	"P2oH,Joystick 1,Enabled,Disabled;",
 	"P2oI,Joystick 2,Enabled,Disabled;",
 
@@ -801,6 +802,7 @@ system system
 	.joystick_ana_1       ({ja_1y,ja_1x}),
 	.joystick_ana_2       ({ja_2y,ja_2x}),
 	.joystick_mode        (status[13:12]),
+	.joystick_timed       (status[59:58]),
 
 	.mgmt_readdata        (mgmt_din),
 	.mgmt_writedata       (mgmt_dout),

--- a/rtl/system.v
+++ b/rtl/system.v
@@ -20,6 +20,7 @@ module system
 	input  [15:0] joystick_ana_1,
 	input  [15:0] joystick_ana_2,
 	input  [1:0]  joystick_mode,
+	input  [1:0]  joystick_timed,
 
 	input  [15:0] mgmt_address,
 	input         mgmt_read,
@@ -550,6 +551,7 @@ joystick joystick
 
 	.clock_rate        (clock_rate),
 
+	.read              (iobus_read & joy_cs),
 	.write             (iobus_write & joy_cs),
 	.readdata          (joystick_readdata),
 
@@ -559,7 +561,8 @@ joystick joystick
 	.dig_2             (joystick_dig_2),
 	.ana_1             (joystick_ana_1),
 	.ana_2             (joystick_ana_2),
-	.mode              (joystick_mode)
+	.mode              (joystick_mode),
+	.timed             (joystick_timed)
 );
 
 pit pit


### PR DESCRIPTION
Fix bug in the frame identification header (5 ones after initial 0) of the Gravis Interface Protocol (GrIP) for joystick 2.

Add axes options because games often use either a timed method or count method to determine the joystick position:
- *Timed*: Simulates the time needed to charge a capacitor through the potentiometer of the joystick to determine its position, using the IBM joystick time formula for a 100 kOhm potentiometer. The timing is fixed and made independent of the CPU speed settings.
- *Count*: The joystick position is determined by the number of reads required before the signal goes low (the number of reads are counted in software and reflect the joystick position). Count 6+256 produces a base count of 6 followed by the current joystick position using a maximum resolution of 256. Because each read triggers a countdown, this method should work regardless the CPU speed settings (unlike the previous implementation).

Regarding the different count options:
- Smaller resolution ranges allow the joystick position to be determined in software using less read cycles (faster), but with maybe reduced resolution (good for platformers, e.g. for Jazz Jackrabbit the maximum count value seems to be 1000 and above this value joysticks will not work).
- Count 8+141 mode is compatible with the DOS game Paratrooper (this game lacks joystick calibration functionality), but can also be used for other games (e.g. platformers).
- For flight simulators with analog joystick support the count 256 mode offers the full analog resolution currently provided.
- Count mode might resolve joystick drift issues observed with the previous implementation.

Refactor and add comments to improve code clarity and maintainability.

Note: The auto switching between analog/d-pad is left in place to see if this update can already help with some of the observed joystick issues (#200, #181, #127, #90, #43).