### PR TITLE
PIT: Allow uninitialized counting in modes 0, 2, 3, 4

### DIFF
--- a/rtl/soc/pit_counter.v
+++ b/rtl/soc/pit_counter.v
@@ -359,7 +359,7 @@ end
 // The counter can be decremented on the falling edge of clock
 wire enable = clock_fall
     && ~load                                      // the counter is not decremented on (re)load
-    && (mode[1:0] == 2'b01 || loaded)             // in modes 0, 2, 3, 4 counting is disabled until the initial count is loaded (disabling this line will fix Lemmings 2 (with Adlib music) on the highest speed settings)
+//    && (mode[1:0] == 2'b01 || loaded)             // in modes 0, 2, 3, 4 counting is disabled until the initial count is loaded (disabling this line will fix Lemmings 2 (with Adlib music) on the highest speed settings)
     && (mode[1:0] == 2'b01 || gate_level_sampled) // in modes 0, 2, 3, 4 the sampled gate level can disable counting
     && ~(mode == 3'd0 && write_seq_msb);          // for mode 0 in read/wite mode 3 (LSB/MSB), writing the first byte disables counting
 


### PR DESCRIPTION
Revert this if it causes PIT issues.

Fixes #199