### PR TITLE
Sound: SB Pro/16 fixes + improved accuracy

### DIFF
--- a/ao486.sv
+++ b/ao486.sv
@@ -197,7 +197,7 @@ led fdd_led(clk_sys, |mgmt_req[7:6], LED_USER);
 // 0         1         2         3          4         5         6
 // 01234567890123456789012345678901 23456789012345678901234567890123
 // 0123456789ABCDEFGHIJKLMNOPQRSTUV 0123456789ABCDEFGHIJKLMNOPQRSTUV
-// XXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXX XXXXXXXXXXXXXXXXXXXXXXXX XXX
+// XXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXX XXXXXXXXXXXXXXXXXXXXXXXXXXXX
 
 `include "build_id.v"
 localparam CONF_STR =
@@ -227,9 +227,10 @@ localparam CONF_STR =
 	"P1-;",
 	"P1O3,FM mode,OPL2,OPL3;",
 	"P1OH,C/MS,Disable,Enable;",
-	"P1OIJ,Speaker Volume,1,2,3,4;",
+	"P1OIJ,PC Speaker Volume,1,2,3,4;",
 	"P1OKL,Audio Boost,No,2x,4x;",
 	"P1oBC,Stereo Mix,none,25%,50%,100%;",
+	"P1oO,SB Swap L/R,Off,On;",
 	"P1OP,MT32 Volume Ctl,MIDI,Line-In;",
 
 	"P2,Hardware;",
@@ -252,7 +253,7 @@ localparam CONF_STR =
 	"P2-;",
 	"P2OA,USER I/O,MIDI,COM2;",
 	"P2-;",
-	"P2OCD,Joystick type,2 Buttons,4 Buttons,Gravis Pro,None;",
+	"P2OCD,Joystick Type,2 Buttons,4 Buttons,Gravis Pro,None;",
 	"P2oFG,Joystick Mode,2 Joysticks,2 Sticks,2 Wheels,4-axes Wheel;",
 	"P2oQR,Joystick Axes,Timed,Count 8+141,Count 0+256,Count 6+256;",
 	"P2oH,Joystick 1,Enabled,Disabled;",
@@ -724,10 +725,6 @@ assign VIDEO_ARY = fb_en ? fb_ary : ary;
 
 assign DDRAM_ADDR[28:25] = 4'h3;
 
-wire [4:0] vol_l, vol_r, vol_cd_l, vol_cd_r, vol_midi_l, vol_midi_r, vol_line_l, vol_line_r;
-wire [1:0] vol_spk;
-wire [4:0] vol_en;
-
 system system
 (
 	.clk_sys              (clk_sys),
@@ -768,18 +765,23 @@ system system
 	.video_lores          (~status[14]),
 	.video_border         (status[55]),
 
+	.sample_cms_l         (cms_out_l),
+	.sample_cms_r         (cms_out_r),
 	.sample_sb_l          (sb_out_l),
 	.sample_sb_r          (sb_out_r),
 	.sample_opl_l         (opl_out_l),
 	.sample_opl_r         (opl_out_r),
 	.sound_fm_mode        (status[3]),
 	.sound_cms_en         (status[17]),
-	.vol_l                (vol_l),
-	.vol_r                (vol_r),
-	.vol_cd_l             (vol_cd_l),
-	.vol_cd_r             (vol_cd_r),
+	.sbp                  (sbp),
+	.vol_master_l         (vol_master_l),
+	.vol_master_r         (vol_master_r),
+	.vol_voice_l          (vol_voice_l),
+	.vol_voice_r          (vol_voice_r),
 	.vol_midi_l           (vol_midi_l),
 	.vol_midi_r           (vol_midi_r),
+	.vol_cd_l             (vol_cd_l),
+	.vol_cd_r             (vol_cd_r),
 	.vol_line_l           (vol_line_l),
 	.vol_line_r           (vol_line_r),
 	.vol_spk              (vol_spk),
@@ -964,9 +966,9 @@ always @(posedge clk_sys) begin
 	mt32_info_req <= (old_mode ^ mt32_newmode) && (mt32_info == 1);
 
 	mt32_info_disp <= (mt32_mode == 'hA2) ? (4'd1 + mt32_sf[2:0]) :
-                     (mt32_mode == 'hA1 && mt32_rom == 0) ?  4'd9 :
-                     (mt32_mode == 'hA1 && mt32_rom == 1) ?  4'd10 :
-                     (mt32_mode == 'hA1 && mt32_rom == 2) ?  4'd11 : 4'd12;
+	                  (mt32_mode == 'hA1 && mt32_rom == 0) ?  4'd9 :
+	                  (mt32_mode == 'hA1 && mt32_rom == 1) ?  4'd10 :
+	                  (mt32_mode == 'hA1 && mt32_rom == 2) ?  4'd11 : 4'd12;
 end
 
 reg mt32_lcd_on;
@@ -992,7 +994,9 @@ wire mt32_lcd = mt32_lcd_on & mt32_lcd_en;
 
 ////////////////////////////  AUDIO  ///////////////////////////////////
 
+// PC Speaker
 wire        speaker_out, speaker_out_clk_audio;
+wire  [1:0] vol_spk;
 reg  [16:0] spk_out;
 
 synchronizer speaker_out_sync
@@ -1008,9 +1012,7 @@ always @(posedge CLK_AUDIO) begin
 	spk_out <= spk >> ~vol_spk;
 end
 
-wire [15:0] sb_out_l, sb_out_r;
-wire [15:0] opl_out_l, opl_out_r;
-
+// CD-DA (Redbook audio)
 wire [15:0] cdda_l;
 wire [15:0] cdda_r;
 wire [31:0] cdda_dout;
@@ -1024,45 +1026,93 @@ cdda #(24576000) cdda
 	.CDDA_WR(cdda_wr),
 	.CDDA_DATA(cdda_dout),
 
-	.VOLUME_L(vol_cd_l[4:1]),
-	.VOLUME_R(vol_cd_r[4:1]),
+	.VOLUME_L(4'b1111),
+	.VOLUME_R(4'b1111),
 
 	.CLK_AUDIO(CLK_AUDIO),
 	.AUDIO_L(cdda_l),
 	.AUDIO_R(cdda_r)
 );
 
-function signed [15:0] volume(input [15:0] inp, input [4:0] vol);
-	begin
-		volume = vol ? $signed($signed(inp) >>> ~vol[4:1]) : 16'd0;
-	end
-endfunction
+wire  [8:0] cms_out_l, cms_out_r;
+wire [15:0] sb_out_l,  sb_out_r;
+wire [15:0] opl_out_l, opl_out_r;
 
-reg [15:0] out_l, out_r;
-always @(posedge CLK_AUDIO) begin
-	reg [16:0] tmp_l, tmp_r;
-	reg [15:0] mt32_l, mt32_r;
+wire        sbp;
+wire  [4:0] vol_master_l, vol_master_r, vol_voice_l, vol_voice_r, vol_midi_l, vol_midi_r, vol_cd_l, vol_cd_r, vol_line_l, vol_line_r;
+wire  [4:0] vol_en;
 
-	mt32_l <= volume(mt32_i2s_l, ~status[25] ? vol_midi_l : vol_en[4] ? vol_line_l : 5'd0);
-	mt32_r <= volume(mt32_i2s_r, ~status[25] ? vol_midi_r : vol_en[3] ? vol_line_r : 5'd0);
+// Select MT-32 volume control
+wire  [4:0] vol_mt32_l = ~status[25] ? vol_midi_l : vol_en[4] ? vol_line_l : 5'd0;
+wire  [4:0] vol_mt32_r = ~status[25] ? vol_midi_r : vol_en[3] ? vol_line_r : 5'd0;
 
-	tmp_l <= {opl_out_l[15],opl_out_l} + {sb_out_l[15],sb_out_l} + spk_out + (mt32_mute ? 17'd0 : {mt32_l[15],mt32_l}) + (vol_en[2] ? {cdda_l[15],cdda_l} : 17'd0);
-	tmp_r <= {opl_out_r[15],opl_out_r} + {sb_out_r[15],sb_out_r} + spk_out + (mt32_mute ? 17'd0 : {mt32_r[15],mt32_r}) + (vol_en[1] ? {cdda_r[15],cdda_r} : 17'd0);
+// Apply per-channel volume controls
+wire [15:0] master_l, master_r, sb_l, sb_r, opl_l, opl_r, cd_l, cd_r, mt32_l, mt32_r;
+wire        sb_volume_valid;
+sb_volume #(.NUM_CH(10), .SAMPLE_WIDTH(16)) sb_volume_inst (
+	.clk(CLK_AUDIO),
+	.sbp(sbp),
+	// Volume controls
+	.volumes_in({vol_master_l, vol_master_r,  // Master volume  
+	             vol_voice_l,  vol_voice_r,   // Voice (SB DAC/DMA)
+	             vol_midi_l,   vol_midi_r,    // MIDI (FM/OPL)
+	             vol_cd_l,     vol_cd_r,      // CD
+	             vol_mt32_l,   vol_mt32_r}),  // MT-32
+	// Pre-volume audio samples
+	.samples_in({mix_pre_l,    mix_pre_r,     // Master mix (pre-volume)
+	             sb_out_l,     sb_out_r,      // SB DAC/DMA
+	             opl_out_l,    opl_out_r,     // OPL2/3 FM synthesis
+	             cdda_l,       cdda_r,        // CD-DA (Redbook audio)
+	             mt32_i2s_l,   mt32_i2s_r}),  // MT-32 I2S
+	// Post-volume audio samples
+	.samples_out({master_l,    master_r,
+	              sb_l,        sb_r,
+	              opl_l,       opl_r,
+	              cd_l,        cd_r,
+	              mt32_l,      mt32_r}),
+	.valid(sb_volume_valid)
+);
 
-	// clamp the output
-	out_l <= (^tmp_l[16:15]) ? {tmp_l[16], {15{tmp_l[15]}}} : tmp_l[15:0];
-	out_r <= (^tmp_r[16:15]) ? {tmp_r[16], {15{tmp_r[15]}}} : tmp_r[15:0];
-end
+// SB channel swap after volume stage
+wire [15:0] sb_l_swap = status[56] ? sb_r : sb_l;
+wire [15:0] sb_r_swap = status[56] ? sb_l : sb_r;
 
-wire [15:0] cmp_l, cmp_r;
-acompr acompr_l(CLK_AUDIO, status[21], out_l, cmp_l);
-acompr acompr_r(CLK_AUDIO, status[21], out_r, cmp_r);
-
+reg [15:0] mix_dry_l, mix_dry_r;
 reg [15:0] audio_l, audio_r;
 always @(posedge CLK_AUDIO) begin
-	audio_l <= volume(status[21:20] ? cmp_l : out_l, vol_l);
-	audio_r <= volume(status[21:20] ? cmp_r : out_r, vol_r);
+	reg [16:0] mix_tmp_l, mix_tmp_r;
+
+	if (sb_volume_valid) begin
+		audio_l <= master_l;
+		audio_r <= master_r;
+
+		mix_tmp_l <= spk_out                                    // PC Speaker
+		           + {2'b00, cms_out_l, cms_out_l[8:4]}         // C/MS or Game Blaster
+		           + {sb_l_swap[15],sb_l_swap}                  // SB DAC/DMA
+		           + {opl_l[15],opl_l}                          // OPL2/3 FM synthesis
+		           + (vol_en[2] ? {cd_l[15],cd_l} : 17'd0)      // CD-DA (Redbook audio)
+		           + (mt32_mute ? 17'd0 : {mt32_l[15],mt32_l}); // MT-32
+		mix_tmp_r <= spk_out
+		           + {2'b00, cms_out_r, cms_out_r[8:4]}
+		           + {sb_r_swap[15],sb_r_swap}
+		           + {opl_r[15],opl_r}
+		           + (vol_en[1] ? {cd_r[15],cd_r} : 17'd0)
+		           + (mt32_mute ? 17'd0 : {mt32_r[15],mt32_r});
+	end
+
+	// Hard clip to prevent overflow
+	mix_dry_l <= (^mix_tmp_l[16:15]) ? {mix_tmp_l[16], {15{mix_tmp_l[15]}}} : mix_tmp_l[15:0];
+	mix_dry_r <= (^mix_tmp_r[16:15]) ? {mix_tmp_r[16], {15{mix_tmp_r[15]}}} : mix_tmp_r[15:0];
 end
+
+// Audio compression
+wire [15:0] mix_cmp_l, mix_cmp_r;
+acompr acompr_l(CLK_AUDIO, status[21], mix_dry_l, mix_cmp_l);
+acompr acompr_r(CLK_AUDIO, status[21], mix_dry_r, mix_cmp_r);
+
+// Select between compressed/dry pre-volume master mix
+wire [15:0] mix_pre_l = status[21:20] ? mix_cmp_l : mix_dry_l;
+wire [15:0] mix_pre_r = status[21:20] ? mix_cmp_r : mix_dry_r;
 
 assign AUDIO_L   = audio_l;
 assign AUDIO_R   = audio_r;

--- a/rtl/soc/sound/sound.v
+++ b/rtl/soc/sound/sound.v
@@ -28,7 +28,7 @@
 module sound
 (
 	input             clk,
-	input			  clk_audio,
+	input             clk_audio,
 	input             rst_n,
 
 	output            irq_5,
@@ -47,12 +47,16 @@ module sound
 	input             fm_mode, // 0 = OPL2, 1 = OPL3
 	input             cms_en,
 
-	output      [4:0] vol_l,
-	output      [4:0] vol_r,
+	output reg        sbp,
+
+	output reg  [4:0] vol_master_l,
+	output reg  [4:0] vol_master_r,
+	output reg  [4:0] vol_voice_l,
+	output reg  [4:0] vol_voice_r,
+	output reg  [4:0] vol_midi_l,
+	output reg  [4:0] vol_midi_r,
 	output reg  [4:0] vol_cd_l,
 	output reg  [4:0] vol_cd_r,
-	output      [4:0] vol_midi_l,
-	output      [4:0] vol_midi_r,
 	output reg  [4:0] vol_line_l,
 	output reg  [4:0] vol_line_r,
 	output reg  [1:0] vol_spk,
@@ -66,10 +70,12 @@ module sound
 	output     [15:0] dma_writedata,
 
 	//sound output
-	output     [15:0] sample_l,
-	output     [15:0] sample_r,
-	output reg [15:0] sample_opl_l,
-	output reg [15:0] sample_opl_r,
+	output      [8:0] sample_cms_l,
+	output      [8:0] sample_cms_r,
+	output     [15:0] sample_sb_l,
+	output     [15:0] sample_sb_r,
+	output     [15:0] sample_opl_l,
+	output     [15:0] sample_opl_r,
 
 	input      [27:0] clock_rate
 );
@@ -77,7 +83,10 @@ module sound
 wire sb_read  = read  & sb_cs;
 wire sb_write = write & sb_cs;
 
-always @(posedge clk) readdata <= mixer_rd ? mixer_val : cms_rd ? data_from_cms : opl_cs ? (opl_dout | (fm_mode ? 8'h00 : 8'h06)) : data_from_dsp;
+always @(posedge clk) readdata <= mixer_rd ? mixer_val : 
+                                  cms_rd   ? data_from_cms : 
+                                  opl_cs   ? (opl_dout | (fm_mode ? 8'h00 : 8'h06)) : 
+                                             data_from_dsp;
 
 //------------------------------------------------------------------------------
 
@@ -104,37 +113,38 @@ wire        irq8, irq16;
 
 sound_dsp sound_dsp_inst
 (
-	.clk             (clk),
-	.rst_n           (rst_n),
+	.clk               (clk),
+	.rst_n             (rst_n),
 
-	.clock_rate      (clk_rate),
+	.clock_rate        (clk_rate),
 
-	.ce_1us          (ce_1us),
+	.ce_1us            (ce_1us),
 
-	.irq8            (irq8),
-	.irq16           (irq16),
+	.irq8              (irq8),
+	.irq16             (irq16),
 
 	//io slave 220h-22Fh
-	.io_address      (address),
-	.io_read         (sb_read),
-	.io_readdata     (data_from_dsp),
-	.io_write        (sb_write),
-	.io_writedata    (writedata),
+	.io_address        (address),
+	.io_read           (sb_read),
+	.io_readdata       (data_from_dsp),
+	.io_write          (sb_write),
+	.io_writedata      (writedata),
 
 	//dma
-	.dma_req8        (dma_req8),
-	.dma_req16       (dma_req16),
-	.dma_ack         (dma_ack),
-	.dma_readdata    (dma_readdata),
-	.dma_writedata   (dma_writedata),
+	.dma_req8          (dma_req8),
+	.dma_req16         (dma_req16),
+	.dma_ack           (dma_ack),
+	.dma_readdata      (dma_readdata),
+	.dma_writedata     (dma_writedata),
 
-	.dma_16_en       (dma_16_en),
-	.sbp             (sbp),
-	.sbp_stereo      (sbp_stereo),
+	.dma_16_en         (dma_16_en),
+	.sbp               (sbp),
+	.sbp_stereo        (sbp_stereo),
+	.sbp_stereo_ff_rst (sbp_stereo_ff_rst),
 
 	//sample
-	.sample_value_l  (dsp_value_l),
-	.sample_value_r  (dsp_value_r)
+	.sample_value_l    (dsp_value_l),
+	.sample_value_r    (dsp_value_r)
 );
 
 wire   irq    = irq8 | irq16;
@@ -144,8 +154,6 @@ assign irq_10 = irq & irq_10_en;
 
 //------------------------------------------------------------------------------ opl
 
-wire [15:0] sample_from_opl_l;
-wire [15:0] sample_from_opl_r;
 wire  [7:0] opl_dout;
 
 wire opl_cs = (           address[2:1] == 0 && sb_cs)  //220-221,228-229
@@ -158,21 +166,21 @@ wire opl_rd = read;
 
 opl3 opl
 (
-    .clk(clk_audio),
-    .clk_host(clk),
+	.clk(clk_audio),
+	.clk_host(clk),
 	.clk_dac(),
-    .ic_n(rst_n),
-    .cs_n(!opl_cs),
-    .rd_n(!opl_rd),
-    .wr_n(!opl_wr),
-    .address(address[1:0]),
-    .din(writedata),
-    .dout(opl_dout),
-    .sample_valid(),
-	.sample_l(sample_from_opl_l),
-	.sample_r(sample_from_opl_r),
-    .led(),
-    .irq_n()
+	.ic_n(rst_n),
+	.cs_n(!opl_cs),
+	.rd_n(!opl_rd),
+	.wr_n(!opl_wr),
+	.address(address[1:0]),
+	.din(writedata),
+	.dout(opl_dout),
+	.sample_valid(),
+	.sample_l(sample_opl_l),
+	.sample_r(sample_opl_r),
+	.led(),
+	.irq_n()
 );
 
 //------------------------------------------------------------------------------ c/ms
@@ -244,138 +252,296 @@ always @(posedge clk) begin
 	else if(write && sb_cs && address == 4'h5 && mixer_reg == 'h81) dma_16_en <= writedata[5];
 end
 
-reg irq_7_en, irq_10_en, sbp;
+reg irq_7_en, irq_10_en;
 always @(posedge clk) begin
 	if(~rst_n)                                                      {sbp,irq_10_en,irq_7_en} <= 0;
 	else if(write && sb_cs && address == 4'h5 && mixer_reg == 'h80) begin
-		if(writedata == 'hAD)      sbp <= 1;
-		else if(writedata == 'hAE) sbp <= 0;
+		if(writedata == 'hAD)      sbp <= 1; // Select SBPro
+		else if(writedata == 'hAE) sbp <= 0; // Select SB16
 		else                       {irq_10_en,irq_7_en} <= {writedata[3:2] == 2'b10, writedata[3:2] == 2'b01};
 	end
 end
 
 wire irq_5_en = ~irq_7_en & ~irq_10_en;
 
-wire [9:0] sb_vol = sbp ? {writedata[7:5], writedata[7:6], writedata[3:1], writedata[3:2]} : {writedata[7:4], writedata[7], writedata[3:0], writedata[3]};
+// Mixer Chip:
+// SBPro 2.0 = CT1345
+// SB16      = CT1745
+
+// This resets the stereo interleaving flip-flop in the Sound Blaster Pro mixer.
+wire sbp_stereo_ff_rst = write && sb_cs && address == 4'h5 && mixer_reg == 8'h0E; // SBPro mixer reg 0Eh write
+
+reg       sbp_stereo;
+reg       sbp_output_lpf_bypass;
+reg       sbp_input_lpf_bypass;
+reg       sbp_input_lpf_freq;
+reg [1:0] sbp_input_source;
+
+// SBPro Volume (3-bit -> 5-bit): From -28 dB to 0 dB in 4 dB steps
+//                                vol_5bit = 5'd17 + (vol_3bit * 2) = {1'b1, vol_3bit, 1'b1}
+// SB16  Volume (4-bit -> 5-bit): From -60 dB to 0 dB in 4 dB steps
+//                                vol_5bit = 5'd01 + (vol_4bit * 2) = {      vol_4bit, 1'b1}
+wire [9:0] vol_mapped = sbp ? {1'b1, writedata[7:5], 1'b1,   1'b1, writedata[3:1], 1'b1}
+                            : {      writedata[7:4], 1'b1,         writedata[3:0], 1'b1};
+
+// Note: SBPDIG.ADV performs a read-modify-write check on the mixer's mic volume register 0Ah
+//       as part of the Sound Blaster Pro detection routine (e.g. Ultima Underworld, Dune II, others...).
+reg [4:0] vol_mic; // SBPro: Mic volume does not affect recording
 
 reg [6:0] rec_en[2];
-reg       sbp_stereo;
-reg [4:0] vol_ma_l, vol_ma_r;
-reg [4:0] vol_vo_l, vol_vo_r;
-reg [4:0] vol_mi_l, vol_mi_r;
+
+reg [1:0] input_gain_l;
+reg [1:0] input_gain_r;
+reg [1:0] output_gain_l;
+reg [1:0] output_gain_r;
+reg       input_agc;
+reg [3:0] treble_l;
+reg [3:0] treble_r;
+reg [3:0] bass_l;
+reg [3:0] bass_r;
+
 always @(posedge clk) begin
 	if(~rst_n || (write && sb_cs && address == 4'h5 && mixer_reg == 8'h00)) begin
-		{vol_ma_l, vol_ma_r} <= 10'h3FF;
-		{vol_vo_l, vol_vo_r} <= 10'h3FF;
-		{vol_mi_l, vol_mi_r} <= 10'h3FF;
-		{vol_cd_l, vol_cd_r} <= 10'h3FF;
-		{vol_line_l, vol_line_r} <= 10'h3FF;
-		vol_spk <= 3;
-		sbp_stereo <= 0;
-		vol_en <= 5'b11111;
-		rec_en[0] <= 7'b0010101;
-		rec_en[1] <= 7'b0001011;
+		sbp_stereo                   <= 1'b0;           // SBPro: Mixer Stereo Switch: 0=mono output, 1=stereo output (interleaved stereo)
+		sbp_output_lpf_bypass        <= 1'b0;           // SBPro: Output Low-Pass Filter: 0=output through lpf, 1=bypass output lpf
+		sbp_input_lpf_bypass         <= 1'b0;           // SBPro: Input Low-Pass Filter: 0=input through lpf, 1=bypass input lpf
+		sbp_input_lpf_freq           <= 1'b0;           // SBPro: Input Low-Pass Filter Frequency: 0=3.2kHz lpf, 1=8.8kHz lpf
+		sbp_input_source             <= 2'h0;           // SBPro: Input Source: 0,2=mic, 1=cd, 3=line
+		vol_mic                      <= 5'h0;           // SBPro: Mic volume control at 4 levels (2 bits) from -46dB to 0dB in approximate 7dB steps
+		                                                // SB16:  Mic volume control at 8 levels (3 bits) from -42dB to 0dB in 6dB steps
+		// Original default volume:
+		// - Master/Voice/MIDI (volume_5bit = 25): -11 dB SBPro, -12 dB SB16
+		// - CD/Line           (volume_5bit = 00): -46 dB SBPro, -62 dB SB16
+		// Note: After each channel volume the master volume will be applied to the whole mix.
+		// The original default volume levels seem to be too low.
+		// Reasonable volume settings with enough headroom?...
+		{vol_master_l, vol_master_r} <= {5'd29, 5'd29}; // SB16:  Master volume control L/R at 32 levels (5 bits) in 2dB steps (SBPro: 8 levels (3 bits) in approximate 4dB steps)
+		{vol_voice_l,  vol_voice_r}  <= {5'd29, 5'd29}; // SB16:  Voice  volume control L/R at 32 levels (5 bits) in 2dB steps (SBPro: 8 levels (3 bits) in approximate 4dB steps)
+		{vol_midi_l,   vol_midi_r}   <= {5'd29, 5'd29}; // SB16:  MIDI   volume control L/R at 32 levels (5 bits) in 2dB steps (SBPro: 8 levels (3 bits) in approximate 4dB steps)
+		{vol_cd_l,     vol_cd_r}     <= {5'd29, 5'd29}; // SB16:  CD     volume control L/R at 32 levels (5 bits) in 2dB steps (SBPro: 8 levels (3 bits) in approximate 4dB steps)
+		{vol_line_l,   vol_line_r}   <= {5'd29, 5'd29}; // SB16:  Line   volume control L/R at 32 levels (5 bits) in 2dB steps (SBPro: 8 levels (3 bits) in approximate 4dB steps)
+		vol_spk                      <= 2'h3;           // SB16:  PC Speaker volume control at 4 levels from -18dB to 0dB in 6dB steps
+		vol_en                       <= 5'b11111;       // SB16:  Output mixer switches:                  line_l, line_r, cd_l, cd_r, mic
+		rec_en[0]                    <= 7'b0010101;     // SB16:  Input mixer l switches: midi_l, midi_r, line_l, line_r, cd_l, cd_r, mic
+		rec_en[1]                    <= 7'b0001011;     // SB16:  Input mixer r switches: midi_l, midi_r, line_l, line_r, cd_l, cd_r, mic
+		input_gain_l                 <= 2'h0;           // SB16:  Input gain control left
+		input_gain_r                 <= 2'h0;           // SB16:  Input gain control right
+		output_gain_l                <= 2'h0;           // SB16:  Output gain control left
+		output_gain_r                <= 2'h0;           // SB16:  Output gain control right
+		input_agc                    <= 1'b0;           // SB16:  Automatic Gain Control (AGC): 0=disabled, 1=enabled
+		treble_l                     <= 4'h8;           // SB16:  Treble left  control: 15 levels from -14dB to 14dB in 2dB steps
+		treble_r                     <= 4'h8;           // SB16:  Treble right control: 15 levels from -14dB to 14dB in 2dB steps
+		bass_l                       <= 4'h8;           // SB16:  Bass left    control: 15 levels from -14dB to 14dB in 2dB steps
+		bass_r                       <= 4'h8;           // SB16:  Bass right   control: 15 levels from -14dB to 14dB in 2dB steps
 	end
 	else if(write && sb_cs && address == 4'h5) begin
-		if(mixer_reg == 8'h0E) sbp_stereo <= writedata[1] & sbp; // only for SBPro!
-		if(mixer_reg == 8'h22) {vol_ma_l, vol_ma_r} <= sb_vol;
-		if(mixer_reg == 8'h26) {vol_mi_l, vol_mi_r} <= sb_vol;
-		if(mixer_reg == 8'h28) {vol_cd_l, vol_cd_r} <= sb_vol;
-		if(mixer_reg == 8'h2E) {vol_line_l, vol_line_r} <= sb_vol;
-		if(~sbp) begin
-			if(mixer_reg == 8'h30) vol_ma_l <= writedata[7:3];
-			if(mixer_reg == 8'h31) vol_ma_r <= writedata[7:3];
-			if(mixer_reg == 8'h32) vol_vo_l <= writedata[7:3];
-			if(mixer_reg == 8'h33) vol_vo_r <= writedata[7:3];
-			if(mixer_reg == 8'h34) vol_mi_l <= writedata[7:3];
-			if(mixer_reg == 8'h35) vol_mi_r <= writedata[7:3];
-			if(mixer_reg == 8'h36) vol_cd_l <= writedata[7:3];
-			if(mixer_reg == 8'h37) vol_cd_r <= writedata[7:3];
-			if(mixer_reg == 8'h38) vol_line_l <= writedata[7:3];
-			if(mixer_reg == 8'h39) vol_line_r <= writedata[7:3];
-			if(mixer_reg == 8'h3B) vol_spk <= writedata[7:6];
-			if(mixer_reg == 8'h3C) vol_en  <= writedata[4:0];
-			if(mixer_reg == 8'h3D) rec_en[0] <= writedata[6:0];
-			if(mixer_reg == 8'h3E) rec_en[1] <= writedata[6:0];
-		end
+		case (mixer_reg)
+			// Common registers (SBPro & SB16)
+			8'h04: {vol_voice_l,  vol_voice_r}  <= vol_mapped;
+			8'h22: {vol_master_l, vol_master_r} <= vol_mapped;
+			8'h26: {vol_midi_l,   vol_midi_r}   <= vol_mapped;
+			8'h28: {vol_cd_l,     vol_cd_r}     <= vol_mapped;
+			8'h2E: {vol_line_l,   vol_line_r}   <= vol_mapped;
+			// SBPro Mic (2-bit -> 5-bit): from -24 dB to 0 dB in 8 dB steps
+			//                             vol_5bit = 5'd19 + (vol_2bit * 4) = {1'b1, vol_2bit, 2'b11}
+			// SB16  Mic (3-bit -> 5-bit): from -42 dB to 0 dB in 6 dB steps
+			//                             vol_5bit = 5'd10 + (vol_3bit * 3) = 5'd10 + (vol_3bit << 1) + vol_3bit
+			8'h0A: vol_mic <= sbp ? {1'b1, writedata[2:1], 2'b11}
+			                      : 5'd10 + {writedata[2:0], 1'b0} + writedata[2:0];
+
+			// SBPro only registers
+			8'h0C: if (sbp) {sbp_input_lpf_bypass, sbp_input_lpf_freq, sbp_input_source} <= {writedata[5], writedata[3], writedata[2:1]};
+			8'h0E: if (sbp) {sbp_output_lpf_bypass, sbp_stereo} <= {writedata[5], writedata[1]};
+
+			// SB16 only registers
+			8'h30: if (!sbp) vol_master_l  <= writedata[7:3];
+			8'h31: if (!sbp) vol_master_r  <= writedata[7:3];
+			8'h32: if (!sbp) vol_voice_l   <= writedata[7:3];
+			8'h33: if (!sbp) vol_voice_r   <= writedata[7:3];
+			8'h34: if (!sbp) vol_midi_l    <= writedata[7:3];
+			8'h35: if (!sbp) vol_midi_r    <= writedata[7:3];
+			8'h36: if (!sbp) vol_cd_l      <= writedata[7:3];
+			8'h37: if (!sbp) vol_cd_r      <= writedata[7:3];
+			8'h38: if (!sbp) vol_line_l    <= writedata[7:3];
+			8'h39: if (!sbp) vol_line_r    <= writedata[7:3];
+			8'h3A: if (!sbp) vol_mic       <= writedata[7:3];
+			8'h3B: if (!sbp) vol_spk       <= writedata[7:6];
+			8'h3C: if (!sbp) vol_en        <= writedata[4:0];
+			8'h3D: if (!sbp) rec_en[0]     <= writedata[6:0];
+			8'h3E: if (!sbp) rec_en[1]     <= writedata[6:0];
+			8'h3F: if (!sbp) input_gain_l  <= writedata[7:6];
+			8'h40: if (!sbp) input_gain_r  <= writedata[7:6];
+			8'h41: if (!sbp) output_gain_l <= writedata[7:6];
+			8'h42: if (!sbp) output_gain_r <= writedata[7:6];
+			8'h43: if (!sbp) input_agc     <= writedata[0];
+			8'h44: if (!sbp) treble_l      <= writedata[7:4];
+			8'h45: if (!sbp) treble_r      <= writedata[7:4];
+			8'h46: if (!sbp) bass_l        <= writedata[7:4];
+			8'h47: if (!sbp) bass_r        <= writedata[7:4];
+
+			default: ; // no change
+		endcase
 	end
 end
 
-assign vol_midi_l = vol_mi_l;
-assign vol_midi_r = vol_mi_r;
-
-wire [7:0] vol_mask = sbp ? 8'hEE : 8'hFF;
+wire [7:0] vol_mic_sum  = {(vol_mic - 5'd10), 3'd0} + {(vol_mic - 5'd10), 1'd0} + (vol_mic - 5'd10);
+wire [2:0] vol_mic_3bit = vol_mic_sum[7:5];
 
 reg [7:0] mixer_val;
 always @(posedge clk) begin
-
 	mixer_val <= 8'h00;
 
-	case(mixer_reg)
-		'h04: mixer_val <= {vol_vo_l[4:1], vol_vo_r[4:1]} & vol_mask;
-		'h0E: mixer_val <= {6'd0, sbp_stereo, 1'b0};
-		'h22: mixer_val <= {vol_ma_l[4:1], vol_ma_r[4:1]} & vol_mask;
-		'h26: mixer_val <= {vol_mi_l[4:1], vol_mi_r[4:1]} & vol_mask;
-		'h28: mixer_val <= {vol_cd_l[4:1], vol_cd_r[4:1]} & vol_mask;
-		'h2E: mixer_val <= {vol_line_l[4:1], vol_line_r[4:1]} & vol_mask;
+	case (mixer_reg)
+		// Common registers (SBPro & SB16)
+		// Note: The Sound Blaster Series 16-bit MASI Driver v2.90 used in games like Epic Pinball (MDRV004R.MUS) and
+		//       Jazz Jackrabbit (MDRV004D.MUS) writes the value F3h to the mixer's master volume register (22h),
+		//       then reads it back to verify. Stereo playback is enabled only if the returned value matches what was written.
+		//       Hence, the reserved bits 0 and 4 in the volume registers 04h, 22h, 26h, 28h, 2Eh must be output
+		//       like the original Sound Blaster Pro does (value 1) to ensure correct stereo detection with this driver.
+		8'h04: mixer_val <= sbp ? { vol_voice_l < 5'd17 ? 3'd0 :  vol_voice_l[3:1], 1'b1,  vol_voice_r < 5'd17 ? 3'd0 :  vol_voice_r[3:1], 1'b1} : { vol_voice_l[4:1],  vol_voice_r[4:1]};
+		8'h22: mixer_val <= sbp ? {vol_master_l < 5'd17 ? 3'd0 : vol_master_l[3:1], 1'b1, vol_master_r < 5'd17 ? 3'd0 : vol_master_r[3:1], 1'b1} : {vol_master_l[4:1], vol_master_r[4:1]};
+		8'h26: mixer_val <= sbp ? {  vol_midi_l < 5'd17 ? 3'd0 :   vol_midi_l[3:1], 1'b1,   vol_midi_r < 5'd17 ? 3'd0 :   vol_midi_r[3:1], 1'b1} : {  vol_midi_l[4:1],   vol_midi_r[4:1]};
+		8'h28: mixer_val <= sbp ? {    vol_cd_l < 5'd17 ? 3'd0 :     vol_cd_l[3:1], 1'b1,     vol_cd_r < 5'd17 ? 3'd0 :     vol_cd_r[3:1], 1'b1} : {    vol_cd_l[4:1],     vol_cd_r[4:1]};
+		8'h2E: mixer_val <= sbp ? {  vol_line_l < 5'd17 ? 3'd0 :   vol_line_l[3:1], 1'b1,   vol_line_r < 5'd17 ? 3'd0 :   vol_line_r[3:1], 1'b1} : {  vol_line_l[4:1],   vol_line_r[4:1]};
+		// SBPro Mic (5-bit -> 2-bit): vol_2bit = (vol_5bit - 5'd19) / 4
+		// SB16  Mic (5-bit -> 3-bit): vol_3bit = (vol_5bit - 5'd10) / 3 = (vol_5bit - 5'd10) * 11/32
+		8'h0A: mixer_val <= sbp ? {5'b00000, (vol_mic < 5'd19 ? 2'd0 : vol_mic[3:2]), 1'b0}
+		                        : {5'b00000, (vol_mic < 5'd10 ? 3'd0 : vol_mic_3bit)};
+
+		// SBPro only registers
+		8'h0C: if (sbp) mixer_val <= {2'b00, sbp_input_lpf_bypass, 1'b0, sbp_input_lpf_freq, sbp_input_source, 1'b1};
+		8'h0E: if (sbp) mixer_val <= {2'b00, sbp_output_lpf_bypass, 1'b1, 2'b00, sbp_stereo, 1'b1};
+
+		// SB16 only registers
+		8'h30: if (!sbp) mixer_val <= {vol_master_l, 3'b000};
+		8'h31: if (!sbp) mixer_val <= {vol_master_r, 3'b000};
+		8'h32: if (!sbp) mixer_val <= {vol_voice_l,  3'b000};
+		8'h33: if (!sbp) mixer_val <= {vol_voice_r,  3'b000};
+		8'h34: if (!sbp) mixer_val <= {vol_midi_l,   3'b000};
+		8'h35: if (!sbp) mixer_val <= {vol_midi_r,   3'b000};
+		8'h36: if (!sbp) mixer_val <= {vol_cd_l,     3'b000};
+		8'h37: if (!sbp) mixer_val <= {vol_cd_r,     3'b000};
+		8'h38: if (!sbp) mixer_val <= {vol_line_l,   3'b000};
+		8'h39: if (!sbp) mixer_val <= {vol_line_r,   3'b000};
+		8'h3A: if (!sbp) mixer_val <= {vol_mic,      3'b000};
+		8'h3B: if (!sbp) mixer_val <= {vol_spk,   6'b000000};
+		8'h3C: if (!sbp) mixer_val <= {3'b000, vol_en};
+		8'h3D: if (!sbp) mixer_val <= {1'b0, rec_en[0]};
+		8'h3E: if (!sbp) mixer_val <= {1'b0, rec_en[1]};
+		8'h3F: if (!sbp) mixer_val <= {input_gain_l,  6'b000000};
+		8'h40: if (!sbp) mixer_val <= {input_gain_r,  6'b000000};
+		8'h41: if (!sbp) mixer_val <= {output_gain_l, 6'b000000};
+		8'h42: if (!sbp) mixer_val <= {output_gain_r, 6'b000000};
+		8'h43: if (!sbp) mixer_val <= {7'b0000000, input_agc};
+		8'h44: if (!sbp) mixer_val <= {treble_l, 4'b0000};
+		8'h45: if (!sbp) mixer_val <= {treble_r, 4'b0000};
+		8'h46: if (!sbp) mixer_val <= {bass_l,   4'b0000};
+		8'h47: if (!sbp) mixer_val <= {bass_r,   4'b0000};
+		8'h80: if (!sbp) mixer_val <= {4'b1111, irq_10_en, irq_7_en, irq_5_en, 1'b0}; // IRQ 10, 7, 5
+		8'h81: if (!sbp) mixer_val <= {1'b0, 1'b0, dma_16_en, 1'b0, 1'b0, 1'b0, 1'b1, 1'b0}; // DMA 5 (16-bit), DMA 1 (8-bit)
+		8'h82: if (!sbp) mixer_val <= {4'b0010, 1'b0, 1'b0, irq16, irq8}; // bits [7:4] = 1h (v4.04), 2h (v4.05), 8h (v4.12)
 	endcase
-
-	if(~sbp) begin
-		case(mixer_reg)
-			'h30: mixer_val <= {vol_ma_l, 3'd0};
-			'h31: mixer_val <= {vol_ma_r, 3'd0};
-			'h32: mixer_val <= {vol_vo_l, 3'd0};
-			'h33: mixer_val <= {vol_vo_r, 3'd0};
-			'h34: mixer_val <= {vol_mi_l, 3'd0};
-			'h35: mixer_val <= {vol_mi_r, 3'd0};
-			'h36: mixer_val <= {vol_cd_l, 3'd0};
-			'h37: mixer_val <= {vol_cd_r, 3'd0};
-			'h38: mixer_val <= {vol_line_l, 3'd0};
-			'h39: mixer_val <= {vol_line_r, 3'd0};
-			'h3B: mixer_val <= {vol_spk, 6'd0};
-			'h3C: mixer_val <= vol_en;
-			'h3D: mixer_val <= rec_en[0];
-			'h3E: mixer_val <= rec_en[1];
-			'h80: mixer_val <= {4'h0, irq_10_en, irq_7_en, irq_5_en, 1'b0}; //IRQ 7 or 5
-			'h81: mixer_val <= {2'b00,dma_16_en,1'b0,4'h2}; //DMA 5/1
-			'h82: mixer_val <= {6'd0, irq16, irq8};
-		endcase;
-	end
-end
-
-function signed [15:0] volume(input [15:0] inp, input [4:0] vol);
-	begin
-		volume = vol ? $signed($signed(inp) >>> ~vol[4:1]) : 16'd0;
-	end
-endfunction
-
-reg [15:0] sample_dsp_l, sample_dsp_r;
-always @(posedge clk) begin
-	sample_dsp_l <= volume(dsp_value_l, vol_vo_l);
-	sample_dsp_r <= volume(dsp_value_r, vol_vo_r);
-end
-
-always @(posedge clk_audio) begin // vol reg expected to be held for a long time, clk domain crossing not a big deal
-	sample_opl_l <= volume(sample_from_opl_l, vol_mi_l);
-	sample_opl_r <= volume(sample_from_opl_r, vol_mi_r);
-end
-
-reg [15:0] sample_l_clk_sys, sample_r_clk_sys;
-always @(posedge clk) begin
-	sample_l_clk_sys <= {sample_dsp_l[15], sample_dsp_l[15:1]} + {2'b00, cms_l, cms_l[8:4]};
-	sample_r_clk_sys <= {sample_dsp_r[15], sample_dsp_r[15:1]} + {2'b00, cms_r, cms_r[8:4]};
 end
 
 cdc_vector_handshake_continuous #(
-    .DATA_WIDTH(16*2)
+	.DATA_WIDTH(16*2 + 9*2)
 ) audio_cdc (
-    .clk_in(clk),
-    .clk_out(clk_audio),
-    .data_in({sample_l_clk_sys, sample_r_clk_sys}),
-    .data_out({sample_l, sample_r})
+	.clk_in(clk),
+	.clk_out(clk_audio),
+	.data_in({dsp_value_l, dsp_value_r, cms_l, cms_r}),
+	.data_out({sample_sb_l, sample_sb_r, sample_cms_l, sample_cms_r})
 );
 
-assign vol_l = vol_ma_l;
-assign vol_r = vol_ma_r;
+endmodule
+
+//------------------------------------------------------------------------------ SB Volume
+
+module sb_volume
+#(
+	parameter integer NUM_CH       = 10, // number of channels
+	parameter integer SAMPLE_WIDTH = 16  // number of bits per sample
+)(
+	input                                clk,
+	input                                sbp,         // SBPro: sbp=1, SB16: sbp=0
+	input                 [NUM_CH*5-1:0] volumes_in,  // input volumes (5 bits per channel volume control)
+	input      [NUM_CH*SAMPLE_WIDTH-1:0] samples_in,  // input samples (SAMPLE_WIDTH bits per channel sample)
+	output reg [NUM_CH*SAMPLE_WIDTH-1:0] samples_out, // output samples (attenuated)
+	output reg                           valid        // samples_out valid flag
+);
+
+// SBPro gain table (unsigned, 16-bit gain values)
+// volume = 0 to 7 (3-bit) => -46 dB to 0 dB, in approximate 4 dB steps
+// 8 x 16 = 128 bits packed into one vector
+localparam [127:0] sbp_gain_lut = {
+	16'hFFFF, //   0 dB (17'h10000 will be used for unity gain)
+	16'hB53C, //  -3 dB
+	16'h725A, //  -7 dB
+	16'h4827, // -11 dB
+	16'h2893, // -16 dB
+	16'h1456, // -22 dB
+	16'h0A31, // -28 dB
+	16'h0148  // -46 dB
+};
+
+// SB16 gain table (unsigned, 16-bit gain values)
+// volume = 0 to 31 (5-bit) => -62 dB to 0 dB, in 2 dB steps
+// 32 x 16 = 512 bits packed into one vector
+localparam [511:0] sb16_gain_lut = {
+	16'hFFFF, //   0 dB (17'h10000 will be used for unity gain)
+	16'hCB59, //  –2 dB
+	16'hA186, //  –4 dB
+	16'h804E, //  –6 dB
+	16'h65EA, //  –8 dB
+	16'h50F4, // –10 dB
+	16'h404E, // –12 dB
+	16'h3314, // –14 dB
+	16'h2893, // –16 dB
+	16'h203A, // –18 dB
+	16'h199A, // –20 dB
+	16'h1456, // –22 dB
+	16'h1027, // –24 dB
+	16'h0CD5, // –26 dB
+	16'h0A31, // –28 dB
+	16'h0818, // –30 dB
+	16'h066E, // –32 dB
+	16'h051C, // –34 dB
+	16'h040F, // –36 dB
+	16'h0339, // –38 dB
+	16'h028F, // –40 dB
+	16'h0209, // –42 dB
+	16'h019E, // –44 dB
+	16'h0148, // –46 dB
+	16'h0105, // –48 dB
+	16'h00CF, // –50 dB
+	16'h00A5, // –52 dB
+	16'h0083, // –54 dB
+	16'h0068, // –56 dB
+	16'h0053, // –58 dB
+	16'h0042, // –60 dB
+	16'h0034  // –62 dB
+};
+
+reg [$clog2(NUM_CH)-1:0] ch;
+
+wire [4:0] volume_5bit = volumes_in[5*ch +: 5];
+wire [2:0] volume_3bit = volume_5bit[3:1];
+
+reg                    [16:0] gain;
+reg signed [SAMPLE_WIDTH-1:0] sample;
+always @(posedge clk) begin
+	gain   <= (volume_5bit == 5'd31) ? 17'h10000 : 
+	                             sbp ?  sbp_gain_lut[volume_3bit*16 +: 16] : 
+	                                   sb16_gain_lut[volume_5bit*16 +: 16];
+	sample <= samples_in[SAMPLE_WIDTH*ch +: SAMPLE_WIDTH];
+end
+
+// DSP-targeted multiply (1 x DSP block shared across all channels)
+wire signed [33:0] gain_product = $signed({1'b0, gain}) * sample;
+
+always @(posedge clk) begin
+	samples_out       <= {gain_product[31:16], samples_out[NUM_CH*SAMPLE_WIDTH-1:SAMPLE_WIDTH]};
+	valid             <= (ch == 0);
+	ch                <= (ch == NUM_CH-1) ? 1'b0 : ch + 1'b1;
+end
 
 endmodule

--- a/rtl/soc/sound/sound_dsp.v
+++ b/rtl/soc/sound/sound_dsp.v
@@ -44,7 +44,7 @@ module sound_dsp
 	output      [7:0] io_readdata,
 	input             io_write,
 	input       [7:0] io_writedata,
-	
+
 	//dma
 	output            dma_req8,
 	output            dma_req16,
@@ -54,6 +54,7 @@ module sound_dsp
 	input             dma_16_en,
 	input             sbp,
 	input             sbp_stereo,
+	input             sbp_stereo_ff_rst,
 
 	//audio
 	output reg [15:0] sample_value_l,
@@ -63,16 +64,20 @@ module sound_dsp
 //------------------------------------------------------------------------------
 
 reg io_read_last;
-always @(posedge clk) begin if(rst_n == 1'b0) io_read_last <= 1'b0; else if(io_read_last) io_read_last <= 1'b0; else io_read_last <= io_read; end 
+always @(posedge clk) begin
+	if (!rst_n)            io_read_last <= 1'b0;
+	else if (io_read_last) io_read_last <= 1'b0;
+	else                   io_read_last <= io_read;
+end
 wire io_read_valid = io_read && io_read_last == 1'b0;
 
 //------------------------------------------------------------------------------
 
 assign io_readdata =
-		(io_address == 4'hA) ? read_buffer[15:8] :
-		(io_address == 4'hC) ? {write_buffer_busy, 7'h7F } :
-		(io_address == 4'hE) ? {read_ready, 7'h7F } :
-                             8'hFF;
+	  (io_address == 4'hA) ? read_buffer[15:8] :
+	  (io_address == 4'hC) ? {write_buffer_busy, 7'h7F } :
+	  (io_address == 4'hE) ? {read_ready, 7'h7F } :
+	                         8'hFF;
 
 //------------------------------------------------------------------------------
 
@@ -80,23 +85,23 @@ wire highspeed_start = cmd_high_auto_dma_out || cmd_high_single_dma_out || cmd_h
 
 reg highspeed_mode;
 always @(posedge clk) begin
-    if(rst_n == 1'b0)           highspeed_mode <= 1'b0;
-    else if(highspeed_reset)    highspeed_mode <= 1'b0;
-    else if(highspeed_start)    highspeed_mode <= 1'b1;
-    else if(dma_finished)       highspeed_mode <= 1'b0;
+	if(!rst_n)                              highspeed_mode <= 1'b0;
+	else if(sw_reset || highspeed_reset)    highspeed_mode <= 1'b0;
+	else if(highspeed_start)                highspeed_mode <= 1'b1;
+	else if(dma_finished)                   highspeed_mode <= 1'b0;
 end
 
 reg midi_uart_mode;
 always @(posedge clk) begin
-    if(rst_n == 1'b0)           midi_uart_mode <= 1'b0;
-    else if(midi_uart_reset)    midi_uart_mode <= 1'b0;
-    else if(cmd_midi_uart)      midi_uart_mode <= 1'b1;
+	if(!rst_n)                  midi_uart_mode <= 1'b0;
+	else if(midi_uart_reset)    midi_uart_mode <= 1'b0;
+	else if(cmd_midi_uart)      midi_uart_mode <= 1'b1;
 end
 
 reg reset_reg;
 always @(posedge clk) begin
-    if(rst_n == 1'b0)                                               reset_reg <= 1'b0;
-    else if(io_write && io_address == 4'h6 && ~(highspeed_mode))    reset_reg <= io_writedata[0];
+	if(!rst_n)                                                      reset_reg <= 1'b0;
+	else if(io_write && io_address == 4'h6 && ~(highspeed_mode))    reset_reg <= io_writedata[0];
 end
 
 wire highspeed_reset = io_write && io_address == 4'h6 &&  highspeed_mode;
@@ -109,18 +114,18 @@ wire input_strobe = cmd_direct_input || dma_input;
 
 reg input_direction;
 always @(posedge clk) begin
-    if(rst_n == 1'b0)                                                       input_direction <= 1'b0;
-    else if(sw_reset)                                                       input_direction <= 1'b0;
-    else if(input_strobe && ~(input_direction) && input_sample == 8'd254)   input_direction <= 1'b1;
-    else if(input_strobe && input_direction    && input_sample == 8'd1)     input_direction <= 1'b0;
+	if(!rst_n)                                                              input_direction <= 1'b0;
+	else if(sw_reset)                                                       input_direction <= 1'b0;
+	else if(input_strobe && ~(input_direction) && input_sample == 8'd254)   input_direction <= 1'b1;
+	else if(input_strobe && input_direction    && input_sample == 8'd1)     input_direction <= 1'b0;
 end
 
 reg [7:0] input_sample;
 always @(posedge clk) begin
-    if(rst_n == 1'b0)                           input_sample <= 8'd128;
-    else if(sw_reset)                           input_sample <= 8'd128;
-    else if(input_strobe && ~(input_direction)) input_sample <= input_sample + 8'd1;
-    else if(input_strobe && input_direction)    input_sample <= input_sample - 8'd1;
+	if(!rst_n)                                  input_sample <= 8'd128;
+	else if(sw_reset)                           input_sample <= 8'd128;
+	else if(input_strobe && ~(input_direction)) input_sample <= input_sample + 8'd1;
+	else if(input_strobe && input_direction)    input_sample <= input_sample - 8'd1;
 end
 
 assign dma_writedata = (dma_id_active) ? {dma_id_value,dma_id_value} : {input_sample,input_sample};
@@ -154,11 +159,11 @@ wire       cmd_finish = cmd_recv_d & ~cmd_recv;
 
 wire [7:0] cmd        = cmd_finish ? cmd_curr : 8'h00;
 
-wire write_buffer_busy = midi_uart_mode || highspeed_mode || (dma_command != S_IDLE) || dsp_fake_busy;
+wire write_buffer_busy = dsp_busy;
 
 reg cmd_recv;
 always @(posedge clk) begin
-	if(rst_n == 1'b0)        cmd_recv <= 1'd0;
+	if(!rst_n)               cmd_recv <= 1'd0;
 	else if(sw_reset)        cmd_recv <= 1'd0;
 	else if(cmd_start)       cmd_recv <= 1'd1;
 	else if(!write_left)     cmd_recv <= 1'd0;
@@ -166,14 +171,14 @@ end
 
 reg cmd_recv_d;
 always @(posedge clk) begin
-	if(rst_n == 1'b0)        cmd_recv_d <= 1'd0;
+	if(!rst_n)               cmd_recv_d <= 1'd0;
 	else if(sw_reset)        cmd_recv_d <= 1'd0;
 	else                     cmd_recv_d <= cmd_recv;
 end
 
 reg [1:0] write_left;
 always @(posedge clk) begin
-	if(rst_n == 1'b0)        write_left <= 2'd0;
+	if(!rst_n)               write_left <= 2'd0;
 	else if(sw_reset)        write_left <= 2'd0;
 	else if(cmd_start)       write_left <= cmd_len;
 	else if(cmd_cont)        write_left <= write_left - 2'd1;
@@ -181,14 +186,14 @@ end
 
 reg [7:0] cmd_curr;
 always @(posedge clk) begin
-	if(rst_n == 1'b0)        cmd_curr <= 8'd0;
+	if(!rst_n)               cmd_curr <= 8'd0;
 	else if(sw_reset)        cmd_curr <= 8'd0;
 	else if(cmd_start)       cmd_curr <= io_writedata;
 end
 
 reg [23:0] write_buffer;
 always @(posedge clk) begin
-	if(rst_n == 1'b0)        write_buffer <= 24'd0;
+	if(!rst_n)               write_buffer <= 24'd0;
 	else if(sw_reset)        write_buffer <= 24'd0;
 	else if(cmd_start)       write_buffer <= 24'd0;
 	else if(cmd_cont)        write_buffer <= { write_buffer[15:0], io_writedata };
@@ -196,6 +201,7 @@ end
 
 //------------------------------------------------------------------------------
 
+// Group 0
 //wire cmd_csp_cmd3               = cmd == 8'h03;
 //wire cmd_csp_set_mode           = cmd == 8'h04;
 //wire cmd_csp_set_par            = cmd == 8'h05;
@@ -203,6 +209,7 @@ wire cmd_csp_get_ver            = cmd == 8'h08;
 //wire cmd_csp_set_reg            = cmd == 8'h0E;
 wire cmd_csp_get_reg            = cmd == 8'h0F;
 
+// Group 1: Primary DMA audio
 wire cmd_direct_output          = cmd == 8'h10;
 wire cmd_single_dma_output      = cmd == 8'h14;
 wire cmd_single_2_adpcm_out     = cmd == 8'h16;
@@ -210,20 +217,32 @@ wire cmd_single_2_adpcm_out_ref = cmd == 8'h17;
 wire cmd_auto_dma_out           = cmd == 8'h1C;
 wire cmd_auto_2_adpcm_out_ref   = cmd == 8'h1F;
 
+// Group 2: Recording control
 wire cmd_direct_input           = cmd == 8'h20;
 wire cmd_single_dma_input       = cmd == 8'h24;
 wire cmd_auto_dma_input         = cmd == 8'h2C;
 
+// Group 3: MIDI operations
 //wire cmd_midi_polling_input     = cmd == 8'h30;
 //wire cmd_midi_interrupt_input   = cmd == 8'h31;
 wire cmd_midi_uart              = { cmd[7:2], 2'b00 } == 8'h34;
 //wire cmd_midi_output            = cmd == 8'h38;
 
+// Group 4: DSP configuration
 wire cmd_set_time_constant      = cmd == 8'h40;
 wire cmd_set_sample_rate        =(cmd == 8'h41 || cmd == 8'h42) && ~sbp;
 wire cmd_auto_dma_continue      =(cmd == 8'h45 || cmd == 8'h47) && ~sbp;
 wire cmd_set_block_size         = cmd == 8'h48;
 
+// Group 5: SBPro RAM playback (DSP v3.xx only)
+//wire cmd_ram_playback_stop      = (cmd == 8'h50 && sbp);
+//wire cmd_ram_playback_start     = (cmd == 8'h51 && sbp);
+//wire cmd_ram_load               = (cmd == 8'h58 && sbp);
+//wire cmd_ram_load_and_playback  = (cmd == 8'h59 && sbp);
+
+// Group 6
+
+// Group 7: Secondary DMA audio
 wire cmd_single_4_adpcm_out     = cmd == 8'h74;
 wire cmd_single_4_adpcm_out_ref = cmd == 8'h75;
 wire cmd_single_3_adpcm_out     = cmd == 8'h76;
@@ -231,15 +250,24 @@ wire cmd_single_3_adpcm_out_ref = cmd == 8'h77;
 wire cmd_auto_4_adpcm_out_ref   = cmd == 8'h7D;
 wire cmd_auto_3_adpcm_out_ref   = cmd == 8'h7F;
 
+// Group 8: Silence generation
 wire cmd_pause_dac              = cmd == 8'h80;
 
-wire cmd_high_auto_dma_out      = cmd == 8'h90;
-wire cmd_high_single_dma_out    = cmd == 8'h91;
-wire cmd_high_auto_dma_input    = cmd == 8'h98;
-wire cmd_high_single_dma_input  = cmd == 8'h99;
+// Group 9: High-speed transfers
+wire cmd_high_auto_dma_out      = (cmd & 8'hF9) == 8'h90; // 90h, 92h, 94h, 96h
+wire cmd_high_single_dma_out    = (cmd & 8'hF9) == 8'h91; // 91h, 93h, 95h, 97h
+wire cmd_high_auto_dma_input    = (cmd & 8'hF9) == 8'h98; // 98h, 9Ah, 9Ch, 9Eh
+wire cmd_high_single_dma_input  = (cmd & 8'hF9) == 8'h99; // 99h, 9Bh, 9Dh, 9Fh
 
+// Group A: SBPro Input Mode Mono/Stereo control (DSP v3.xx only)
+//wire cmd_input_mode_mono        = (cmd & 8'hF8) == 8'hA0 && sbp; // A0h-A7h
+//wire cmd_input_mode_stereo      = (cmd & 8'hF8) == 8'hA8 && sbp; // A8h-AFh
+
+// Group B: SB16 16-bit DMA mode (DSP v4.xx only)
+// Group C: SB16  8-bit DMA mode (DSP v4.xx only)
 wire cmd_new_dma                =(cmd[7:4] == 4'hB || cmd[7:4] == 4'hC) && ~sbp;
 
+// Group D: Miscellaneous
 wire cmd_dma_pause_start        = cmd == 8'hD0 || (cmd == 8'hD5 && ~sbp);
 wire cmd_speaker_on             = cmd == 8'hD1;
 wire cmd_speaker_off            = cmd == 8'hD3;
@@ -247,16 +275,18 @@ wire cmd_dma_pause_end          = cmd == 8'hD4 || (cmd == 8'hD6 && ~sbp);
 wire cmd_speaker_status         = cmd == 8'hD8;
 wire cmd_auto_dma_exit          = cmd == 8'hDA || (cmd == 8'hD9 && ~sbp);
 
+// Group E: DSP identification
 wire cmd_dsp_identification     = cmd == 8'hE0;
 wire cmd_dsp_version            = cmd == 8'hE1;
 wire cmd_dma_id                 = cmd == 8'hE2;
-wire cmd_copyright              = cmd == 8'hE3;
+wire cmd_copyright              =(cmd == 8'hE3 && ~sbp);
 wire cmd_test_register_write    = cmd == 8'hE4;
 wire cmd_test_register_read     = cmd == 8'hE8;
 
+// Group F: Auxiliary commands
 wire cmd_trigger_irq8           = cmd == 8'hF2;
 wire cmd_trigger_irq16          =(cmd == 8'hF3 && ~sbp);
-wire cmd_f8_zero                = cmd == 8'hF8;
+wire cmd_dsp_ram_test           = cmd == 8'hF8;
 wire cmd_f9_test                = cmd == 8'hF9;
 
 wire cmd_new_single_output      = cmd_new_dma & ~cmd[2] & ~cmd[3];
@@ -302,13 +332,13 @@ wire read_reply = io_read_valid && io_address == 4'hA;
 
 reg [1:0] read_buffer_size;
 always @(posedge clk) begin
-	if(rst_n == 1'b0)                       read_buffer_size <= 2'd0;
+	if(!rst_n)                              read_buffer_size <= 2'd0;
 	else if(sw_reset)                       read_buffer_size <= 2'd1;
 	else if(cmd_dsp_version)                read_buffer_size <= 2'd2;
 	else if(cmd_direct_input)               read_buffer_size <= 2'd1;
 	else if(cmd_speaker_status)             read_buffer_size <= 2'd1;
 	else if(cmd_dsp_identification)         read_buffer_size <= 2'd1;
-	else if(cmd_f8_zero)                    read_buffer_size <= 2'd1;
+	else if(cmd_dsp_ram_test)               read_buffer_size <= 2'd1;
 	else if(cmd_test_register_read)         read_buffer_size <= 2'd1;
 	else if(cmd_csp_get_ver & ~sbp)         read_buffer_size <= 2'd1;
 	else if(cmd_csp_get_reg & ~sbp)         read_buffer_size <= 2'd1;
@@ -318,56 +348,58 @@ always @(posedge clk) begin
 	else if(read_reply && read_buffer_size) read_buffer_size <= read_buffer_size - 2'd1;
 end
 
-localparam COPY_STR = 368'h434F505952494748542028432920435245415449564520544543484E4F4C4F4759204C54442C20313939322E0000;
+localparam COPY_STR_SB16 = 368'h434F505952494748542028432920435245415449564520544543484E4F4C4F4759204C54442C20313939322E0000;
+localparam COPY_CNT_SB16 = 6'd45;
 
 reg [5:0] copy_cnt;
 always @(posedge clk) begin
-	if(~rst_n | sw_reset)                   copy_cnt <= 6'd0;
-	else if(cmd_copyright)                  copy_cnt <= 6'd45;
+	if(!rst_n | sw_reset)                   copy_cnt <= 6'd0;
+	else if(cmd_copyright)                  copy_cnt <= COPY_CNT_SB16;
 	else if(cmd)                            copy_cnt <= 6'd0;
 	else if(read_reply && copy_cnt)         copy_cnt <= copy_cnt - 1'd1;
 end
 
 reg [15:0] read_buffer;
 always @(posedge clk) begin
-	if(rst_n == 1'b0)                       read_buffer <= 16'd0;
+	if(!rst_n)                              read_buffer <= 16'd0;
 	else if(sw_reset)                       read_buffer <= { 8'hAA, 8'hAA };
-	else if(cmd_dsp_version)                read_buffer <= sbp ? { 8'h03, 8'h02 } : { 8'h04, 8'h05 };
+	else if(cmd_dsp_version)                read_buffer <= sbp ? { 8'h03, 8'h02 } : { 8'h04, 8'h05 }; // DSP Version: sbp=v3.02, sb16=v4.05
 	else if(cmd_direct_input)               read_buffer <= { input_sample, input_sample };
 	else if(cmd_speaker_status)             read_buffer <= (speaker_on)? 16'hFFFF : 16'h0000;
 	else if(cmd_dsp_identification)         read_buffer <= { ~write_buffer[7:0], ~write_buffer[7:0] };
-	else if(cmd_f8_zero)                    read_buffer <= { 8'h00, 8'h00 };
+	else if(cmd_dsp_ram_test)               read_buffer <= { 8'h00, 8'h00 };
 	else if(cmd_test_register_read)         read_buffer <= { test_register, test_register };
 	else if(cmd_copyright)                  read_buffer <= 16'd0;
 	else if(cmd_csp_get_ver & ~sbp)         read_buffer <= 16'hFFFF;
 	else if(cmd_csp_get_reg & ~sbp)         read_buffer <= (write_buffer[7:0] == 8'h09) ? 16'hF8F8 : 16'hFFFF;
 	else if(cmd_f9_test & ~sbp)             read_buffer <= (write_buffer[7:0] == 8'h0E) ? 16'hFFFF :
-                                                          (write_buffer[7:0] == 8'h0F) ? 16'h0707 :
-																			 (write_buffer[7:0] == 8'h37) ? 16'h3838 : 16'h0000;	
+	                                                       (write_buffer[7:0] == 8'h0F) ? 16'h0707 :
+	                                                       (write_buffer[7:0] == 8'h37) ? 16'h3838 : 16'h0000;	
 
 	else if(read_reply && read_buffer_size) read_buffer[15:8] <= read_buffer[7:0]; // repeat last byte
-	else if(copy_cnt)                       read_buffer[15:8] <= COPY_STR[(copy_cnt*8) +:8];
+	else if(copy_cnt)                       read_buffer[15:8] <= COPY_STR_SB16[(copy_cnt*8) +:8];
 end
 
-//------------------------------------------------------------------------------ 'weird dma identification' from DosBox
+//------------------------------------------------------------------------------ Command E2: Firmware Validation
+// Performs challenge/response authentication using DSP ID registers
 
 reg [7:0] dma_id_value;
 always @(posedge clk) begin
-	if(rst_n == 1'b0)   dma_id_value <= 8'hAA;
+	if(!rst_n)          dma_id_value <= 8'hAA;
 	else if(sw_reset)   dma_id_value <= 8'hAA;
 	else if(cmd_dma_id) dma_id_value <= dma_id_value + (write_buffer[7:0] ^ dma_xor_value);
 end
 
 reg [7:0] dma_xor_value;
 always @(posedge clk) begin
-	if(rst_n == 1'b0)   dma_xor_value <= 8'h96;
+	if(!rst_n)          dma_xor_value <= 8'h96;
 	else if(sw_reset)   dma_xor_value <= 8'h96;
 	else if(cmd_dma_id) dma_xor_value <= {dma_xor_value[1:0],dma_xor_value[7:2]};
 end
 
 reg dma_id_active;
 always @(posedge clk) begin
-	if(rst_n == 1'b0)   dma_id_active <= 1'b0;
+	if(!rst_n)          dma_id_active <= 1'b0;
 	else if(sw_reset)   dma_id_active <= 1'b0;
 	else if(cmd_dma_id) dma_id_active <= 1'b1;
 	else if(dma_ack_w)  dma_id_active <= 1'b0;
@@ -377,93 +409,80 @@ end
 
 reg [7:0] test_register;
 always @(posedge clk) begin
-	if(rst_n == 1'b0)                   test_register <= 8'd0;
+	if(!rst_n)                          test_register <= 8'd0;
 	else if(cmd_test_register_write)    test_register <= write_buffer[7:0];
 end
 
 reg speaker_on; // not affecting actual output on DSP 4.xx
 always @(posedge clk) begin
-	if(rst_n == 1'b0)           speaker_on <= 1'b0;
+	if(!rst_n)                  speaker_on <= 1'b0;
 	else if(sw_reset)           speaker_on <= 1'b0;
 	else if(cmd_speaker_on)     speaker_on <= 1'b1;
 	else if(cmd_speaker_off)    speaker_on <= 1'b0;
 end
 
+//reg input_stereo;
+//always @(posedge clk) begin
+//	if(!rst_n)                        input_stereo <= 1'b0;
+//	else if(sw_reset)                 input_stereo <= 1'b0;
+//	else if(cmd_input_mode_stereo)    input_stereo <= 1'b1;
+//	else if(cmd_input_mode_mono)      input_stereo <= 1'b0;
+//end
+
 reg [15:0] block_size;
 always @(posedge clk) begin
-	if(rst_n == 1'b0)                                block_size <= 16'd0;
+	if(!rst_n)                                       block_size <= 16'h07ff;
 	else if(sw_reset)                                block_size <= 16'd0;
 	else if(cmd_set_block_size | cmd_new_block_size) block_size <= { write_buffer[7:0], write_buffer[15:8] };
 end
 
-reg pause_dma;
-always @(posedge clk) begin
-	if(rst_n == 1'b0)                                                   pause_dma <= 1'b0;
-	else if(sw_reset)                                                   pause_dma <= 1'b0;
-	else if(cmd_dma_pause_start)                                        pause_dma <= 1'b1;
-	else if(cmd_dma_pause_end || dma_single_start || dma_auto_start)    pause_dma <= 1'b0;
-end
-
 //------------------------------------------------------------------------------ pause dac
 
-wire pause_interrupt = !pause_counter && ce_smp && &pause_period;
-
-reg pause_active;
+reg pause_active; // mode_silence
 always @(posedge clk) begin
-	if(rst_n == 1'b0)                        pause_active <= 1'b0;
-	else if(sw_reset)                        pause_active <= 1'b0;
-	else if(cmd_pause_dac)                   pause_active <= 1'b1;
-	else if(!pause_counter && !pause_period) pause_active <= 1'b0;
+	if(!rst_n)                pause_active <= 1'b0;
+	else if(sw_reset)         pause_active <= 1'b0;
+	else if(pause_finished)   pause_active <= 1'b0;
+	else if(cmd_pause_dac)    pause_active <= 1'b1;
 end
 
-reg [15:0] pause_counter;
-always @(posedge clk) begin
-	if(rst_n == 1'b0)                        pause_counter <= 16'd0;
-	else if(sw_reset)                        pause_counter <= 16'd0;
-	else if(cmd_pause_dac)                   pause_counter <= { write_buffer[7:0], write_buffer[15:8] };
-	else if(!pause_period && pause_counter)  pause_counter <= pause_counter - 1'd1;
-end
+wire pause_decrement = pause_active && timer_0_isr;
+wire pause_finished  = pause_decrement && !len_left;
 
-reg [7:0] pause_period;
-always @(posedge clk) begin
-	if(rst_n == 1'b0)                       pause_period <= 8'd0;
-	else if(sw_reset)                       pause_period <= 8'd0;
-	else if(cmd_pause_dac)                  pause_period <= period;
-	else if(!pause_period && pause_counter) pause_period <= period;
-	else if(ce_smp && pause_period)         pause_period <= pause_period + 1'd1;
-end
-
-reg [7:0] period;
-always @(posedge clk) begin
-	if(rst_n == 1'b0)                       period <= 128;
-	else if(sw_reset)                       period <= 128;
-	else if(cmd_set_time_constant)          period <= write_buffer[7:0];
-	else if(cmd_set_sample_rate)            period <= 255;
-end
+//------------------------------------------------------------------------------ sample clk
 
 reg ce_smp;
 always @(posedge clk) begin
 	reg [27:0] sum = 0;
-
-	ce_smp = 0;
-	sum = sum + clk_smp;
-	if(sum >= clock_rate) begin
-		sum = sum - clock_rate;
-		ce_smp = 1;
+	if(!rst_n) begin
+		sum = 0;
+	end else begin
+		ce_smp = 0;
+		sum = sum + clk_smp;
+		if(sum >= clock_rate) begin
+			sum = sum - clock_rate;
+			ce_smp = 1;
+		end
 	end
 end
 
 reg [27:0] clk_smp;
 always @(posedge clk) begin
-	if(!rst_n || sw_reset || cmd_set_time_constant) clk_smp <= 1000000;
+	if(!rst_n || sw_reset || cmd_set_time_constant) clk_smp <= 1000000; // 1 MHz
 	else if(cmd_set_sample_rate)                    clk_smp <= write_buffer[15:0];
+end
+
+reg sample_rate_active;
+always @(posedge clk) begin
+	if(!rst_n || sw_reset || cmd_set_time_constant) sample_rate_active <= 1'b0;
+	else if(cmd_set_sample_rate)                    sample_rate_active <= 1'b1;
 end
 
 //------------------------------------------------------------------------------ irq
 
 always @(posedge clk) begin
-	if(~rst_n || sw_reset)                                                        irq8 <= 1'b0;
-	else if((dma_finished || dma_auto_restart || pause_interrupt) && ~dma_16_req) irq8 <= 1'b1;
+	if(!rst_n || sw_reset)                                                        irq8 <= 1'b0;
+	else if((dma_finished || pause_finished || dma_auto_restart) && ~dma_16_req)  irq8 <= 1'b1;
 	else if(trg_irq8)                                                             irq8 <= 1'b1;
 	else if(io_read_valid && io_address == 4'hE)                                  irq8 <= 1'b0;
 end
@@ -476,14 +495,14 @@ always @(posedge clk) begin
 	trg_irq8 <= &cnt;
 	if(cnt) cnt <= cnt + 1'd1;
 
-	if(~rst_n || sw_reset)                               cnt <= 8'b0;
+	if(!rst_n || sw_reset)                               cnt <= 8'b0;
 	else if(cmd_trigger_irq8)                            cnt <= 8'b1;
 	else if(io_read_valid && io_address == 4'hE && irq8) cnt <= 8'b0;
 end
 
 always @(posedge clk) begin
-	if(~rst_n || sw_reset)                                                        irq16 <= 1'b0;
-	else if((dma_finished || dma_auto_restart || pause_interrupt) && dma_16_req)  irq16 <= 1'b1;
+	if(!rst_n || sw_reset)                                                        irq16 <= 1'b0;
+	else if((dma_finished || pause_finished || dma_auto_restart) && dma_16_req)   irq16 <= 1'b1;
 	else if(cmd_trigger_irq16)                                                    irq16 <= 1'b1;
 	else if(io_read_valid && io_address == 4'hF)                                  irq16 <= 1'b0;
 end
@@ -516,7 +535,7 @@ localparam [4:0] S_IN_AUTO_NEW          = 5'd21;
 reg [4:0] dma_command;
 
 always @(posedge clk) begin
-	if(rst_n == 1'b0)                           dma_command <= S_IDLE;
+	if(!rst_n)                                  dma_command <= S_IDLE;
 	else if(sw_reset)                           dma_command <= S_IDLE;
 
 	else if(cmd_single_dma_output)              dma_command <= S_OUT_SINGLE_8_BIT;
@@ -553,92 +572,160 @@ end
 //------------------------------------------------------------------------------ dma
 
 wire dma_single_start = dma_restart_possible && (
-    dma_command == S_OUT_SINGLE_8_BIT || dma_command == S_OUT_SINGLE_4_BIT     || dma_command == S_OUT_SINGLE_3_BIT     || dma_command == S_OUT_SINGLE_2_BIT     ||
-                                         dma_command == S_OUT_SINGLE_4_BIT_REF || dma_command == S_OUT_SINGLE_3_BIT_REF || dma_command == S_OUT_SINGLE_2_BIT_REF ||
-    dma_command == S_IN_SINGLE ||
-    dma_command == S_OUT_SINGLE_HIGH || dma_command == S_IN_SINGLE_HIGH ||
-	 dma_command == S_OUT_SINGLE_NEW  || dma_command == S_IN_SINGLE_NEW
+	dma_command == S_OUT_SINGLE_8_BIT || dma_command == S_OUT_SINGLE_4_BIT     || dma_command == S_OUT_SINGLE_3_BIT     || dma_command == S_OUT_SINGLE_2_BIT     ||
+	                                     dma_command == S_OUT_SINGLE_4_BIT_REF || dma_command == S_OUT_SINGLE_3_BIT_REF || dma_command == S_OUT_SINGLE_2_BIT_REF ||
+	dma_command == S_IN_SINGLE ||
+	dma_command == S_OUT_SINGLE_HIGH || dma_command == S_IN_SINGLE_HIGH ||
+	dma_command == S_OUT_SINGLE_NEW  || dma_command == S_IN_SINGLE_NEW
 );
 
 wire dma_auto_start = dma_restart_possible && (
-    dma_command == S_OUT_AUTO_8_BIT || dma_command == S_OUT_AUTO_4_BIT_REF || dma_command == S_OUT_AUTO_3_BIT_REF || dma_command == S_OUT_AUTO_2_BIT_REF ||
-    dma_command == S_IN_AUTO ||
-    dma_command == S_OUT_AUTO_HIGH || dma_command == S_IN_AUTO_HIGH ||
-	 dma_command == S_OUT_AUTO_NEW  || dma_command == S_IN_AUTO_NEW
+	dma_command == S_OUT_AUTO_8_BIT || dma_command == S_OUT_AUTO_4_BIT_REF || dma_command == S_OUT_AUTO_3_BIT_REF || dma_command == S_OUT_AUTO_2_BIT_REF ||
+	dma_command == S_IN_AUTO ||
+	dma_command == S_OUT_AUTO_HIGH || dma_command == S_IN_AUTO_HIGH ||
+	dma_command == S_OUT_AUTO_NEW  || dma_command == S_IN_AUTO_NEW
 );
 
 wire dma_new_start = dma_restart_possible && (
-	 dma_command == S_OUT_SINGLE_NEW  || dma_command == S_IN_SINGLE_NEW ||
-	 dma_command == S_OUT_AUTO_NEW  || dma_command == S_IN_AUTO_NEW
+	dma_command == S_OUT_SINGLE_NEW  || dma_command == S_IN_SINGLE_NEW ||
+	dma_command == S_OUT_AUTO_NEW  || dma_command == S_IN_AUTO_NEW
 );
 
-wire dma_normal_req = dma_in_progress && dma_wait == 16'd0 && adpcm_wait == 2'd0 && ~(pause_dma);
+reg dma_normal_req;
+always @(posedge clk) begin
+	if(!rst_n)                                                               dma_normal_req <= 1'b0;
+	else if(sw_reset || highspeed_reset)                                     dma_normal_req <= 1'b0;
+	else if(dma_valid)                                                       dma_normal_req <= 1'b0;
+	else if(dma_in_progress && timer_0_isr && !adpcm_wait && ~pause_active)  dma_normal_req <= 1'b1;
+end
 
 wire dma_valid  = dma_normal_req && dma_ack_w && ~dma_id_active;
 wire dma_output = ~dma_is_input && dma_valid;
 wire dma_input  =  dma_is_input && dma_valid;
 
-wire dma_finished = dma_in_progress && ~dma_autoinit && (
-    ((dma_valid|dma_ack_stereo) && dma_left == 17'd1 && adpcm_type == ADPCM_NONE) ||
-    (adpcm_output && dma_left == 17'd0 && adpcm_type != ADPCM_NONE && adpcm_wait == 2'd1)
+wire dma_finished = dma_in_progress && ~dma_autoinit && !len_left && (
+	(adpcm_type == ADPCM_NONE && (dma_valid|dma_ack_stereo)) ||
+	(adpcm_type != ADPCM_NONE && adpcm_output && adpcm_wait == 2'd1)
 );
-    
-wire dma_auto_restart = dma_in_progress && dma_autoinit && (
-    ((dma_valid|dma_ack_stereo) && dma_left == 17'd1 && adpcm_type == ADPCM_NONE) ||
-    (adpcm_output && dma_left == 17'd0 && adpcm_type != ADPCM_NONE && adpcm_wait == 2'd1)
+
+wire dma_auto_restart = dma_in_progress && dma_autoinit && !len_left && (
+	(adpcm_type == ADPCM_NONE && (dma_valid|dma_ack_stereo)) ||
+	(adpcm_type != ADPCM_NONE && adpcm_output && adpcm_wait == 2'd1)
 );
 
 // After receiving a new DMA command the DSP will finish transferring any bytes for the current output command,
 // or if DMA has been paused then a new command can start immediately.
-wire dma_restart_possible = pause_dma || (!dma_wait && (!adpcm_wait || (adpcm_type != ADPCM_NONE && adpcm_wait == 2'd1)) && (~(dma_in_progress) || dma_auto_restart));
+wire dma_restart_possible = ~tr0 || (
+	(!adpcm_wait || (adpcm_type != ADPCM_NONE && adpcm_wait == 2'd1)) && 
+	(~dma_in_progress || dma_auto_restart)
+);
 
-reg [16:0] dma_left;
+reg [15:0] len_left;
 always @(posedge clk) begin
-	if(rst_n == 1'b0)                           dma_left <= 17'd0;
-	else if(sw_reset)                           dma_left <= 17'd0;
-	else if(dma_single_start)                   dma_left <= {1'b0, write_buffer[7:0], write_buffer[15:8] } + 1'd1;
-	else if(dma_auto_start || dma_auto_restart) dma_left <= {1'b0, block_size} + 1'd1;
-	else if(dma_ack_stereo && dma_left > 17'd0) dma_left <= dma_left - 1'd1;
-	else if(dma_valid && dma_left > 17'd0)      dma_left <= dma_left - 1'd1;
-	else if(dma_finished)                       dma_left <= 17'd0;
+	if(!rst_n)                                                      len_left <= 16'd0;
+	else if(sw_reset || highspeed_reset)                            len_left <= 16'd0;
+	else if((dma_single_start && ~highspeed_mode) || cmd_pause_dac) len_left <= { write_buffer[7:0], write_buffer[15:8] };
+	else if(dma_auto_start || dma_auto_restart || highspeed_start)  len_left <= { block_size };
+	else if((dma_valid|dma_ack_stereo) && len_left > 16'd0)         len_left <= len_left - 1'd1;
+	else if(pause_decrement && len_left > 16'd0)                    len_left <= len_left - 1'd1;
+	else if(pause_finished || dma_finished)                         len_left <= 16'd0;
 end
 
 reg dma_in_progress;
 always @(posedge clk) begin
-	if(rst_n == 1'b0)                           dma_in_progress <= 1'b0;
-	else if(sw_reset)                           dma_in_progress <= 1'b0;
-	else if(dma_single_start || dma_auto_start) dma_in_progress <= 1'b1;
-	else if(dma_finished)                       dma_in_progress <= 1'b0;
+	if(!rst_n)                                                       dma_in_progress <= 1'b0;
+	else if(sw_reset || highspeed_reset)                             dma_in_progress <= 1'b0;
+	else if(cmd_dma_pause_start || dma_finished)                     dma_in_progress <= 1'b0;
+	else if(cmd_dma_pause_end || dma_single_start || dma_auto_start) dma_in_progress <= 1'b1;
 end
 
 reg dma_is_input;
 always @(posedge clk) begin
-	if(rst_n == 1'b0)                                                         dma_is_input <= 1'b0;
-	else if(sw_reset)                                                         dma_is_input <= 1'b0;
+	if(!rst_n)                                                                dma_is_input <= 1'b0;
+	else if(sw_reset || highspeed_reset)                                      dma_is_input <= 1'b0;
 	else if((dma_single_start || dma_auto_start) 
 	 && (   dma_command == S_IN_SINGLE      || dma_command == S_IN_AUTO
 	     || dma_command == S_IN_SINGLE_HIGH || dma_command == S_IN_AUTO_HIGH
-		  || dma_command == S_IN_SINGLE_NEW  || dma_command == S_IN_AUTO_NEW)) dma_is_input <= 1'b1;
+	     || dma_command == S_IN_SINGLE_NEW  || dma_command == S_IN_AUTO_NEW)) dma_is_input <= 1'b1;
 	else if(dma_single_start || dma_auto_start)                               dma_is_input <= 1'b0;
 end
 
 reg dma_autoinit;
 always @(posedge clk) begin
-	if(rst_n == 1'b0)              dma_autoinit <= 1'b0;
-	else if(sw_reset)              dma_autoinit <= 1'b0;
-	else if(dma_single_start)      dma_autoinit <= 1'b0;
-	else if(dma_auto_start)        dma_autoinit <= 1'b1;
-	else if(cmd_auto_dma_exit)     dma_autoinit <= 1'b0;
-	else if(cmd_auto_dma_continue) dma_autoinit <= 1'b1;
+	if(!rst_n)                           dma_autoinit <= 1'b0;
+	else if(sw_reset || highspeed_reset) dma_autoinit <= 1'b0;
+	else if(dma_single_start)            dma_autoinit <= 1'b0;
+	else if(dma_auto_start)              dma_autoinit <= 1'b1;
+	else if(cmd_auto_dma_exit)           dma_autoinit <= 1'b0;
+	else if(cmd_auto_dma_continue)       dma_autoinit <= 1'b1;
 end
 
-reg [7:0] dma_wait;
+//------------------------------------------------------------------------------ 8051 Timer 0 in Mode 2
+
+// 8051 Timer 0 in Mode 2
+// th0 = timer 0 reload value
+// tl0 = timer 0 count value (incrementing)
+// tf0 = timer 0 overflow pulse
+// tr0 = timer 0 run enable
+// et0 = timer 0 interrupt enable
+
+localparam COLD_BOOT_TIME_CONSTANT = 8'h9C;
+
+reg [7:0] time_constant;
 always @(posedge clk) begin
-	if(rst_n == 1'b0)                                                                         dma_wait <= 8'd0;
-	else if(sw_reset)                                                                         dma_wait <= 8'd0;
-	else if(dma_finished || dma_valid || adpcm_output || dma_single_start || dma_auto_start)  dma_wait <= period;
-	else if(~(pause_dma) && ce_smp && dma_wait)                                               dma_wait <= dma_wait + 1'd1;
+	if(!rst_n)                     time_constant <= COLD_BOOT_TIME_CONSTANT; // cold boot
+	else if(sw_reset)              time_constant <= COLD_BOOT_TIME_CONSTANT; // cold boot
+	else if(cmd_set_time_constant) time_constant <= write_buffer[7:0];
 end
+
+reg [7:0] th0;
+always @(posedge clk) begin
+	if(!rst_n)                     th0 <= COLD_BOOT_TIME_CONSTANT; // cold boot
+	else if(sw_reset)              th0 <= COLD_BOOT_TIME_CONSTANT; // cold boot
+	else if(highspeed_reset)       th0 <= time_constant;           // warm boot
+	else if(cmd_set_time_constant) th0 <= write_buffer[7:0];
+end
+
+reg [7:0] tl0;
+always @(posedge clk) begin
+	if(!rst_n)                     tl0 <= COLD_BOOT_TIME_CONSTANT; // cold boot
+	else if(sw_reset)              tl0 <= COLD_BOOT_TIME_CONSTANT; // cold boot
+	else if(highspeed_reset)       tl0 <= time_constant;           // warm boot
+	else if(sample_rate_active)    tl0 <= 8'hFF;                   // SB16 sample rate
+	else if(cmd_set_time_constant) tl0 <= write_buffer[7:0];
+	else if(tf0)                   tl0 <= th0;                     // timer 0 reload on overflow
+	else if(timer_0_tick)          tl0 <= tl0 + 1'd1;              // timer 0 increment
+end
+
+wire timer_0_tick = ce_smp && tr0;
+wire tf0 = timer_0_tick && tl0 == 8'hFF; // timer 0 overflow
+wire timer_0_isr = tf0 && et0; // assume: ea = 1 (global interrupt enable)
+
+reg tr0;
+always @(posedge clk) begin
+	if(!rst_n)                                                                        tr0 <= 1'b0;
+	else if(sw_reset || highspeed_reset)                                              tr0 <= 1'b0;
+	else if(cmd_dma_pause_start || pause_finished || dma_finished)                    tr0 <= 1'b0;
+	else if(cmd_dma_pause_end || cmd_pause_dac || dma_single_start || dma_auto_start) tr0 <= 1'b1;
+end
+
+reg et0;
+always @(posedge clk) begin
+	if(!rst_n)                                                                        et0 <= 1'b0;
+	else if(sw_reset || highspeed_reset)                                              et0 <= 1'b0;
+	else if(cmd_dma_pause_start || pause_finished || dma_finished)                    et0 <= 1'b0;
+	else if(cmd_dma_pause_end || cmd_pause_dac || dma_single_start || dma_auto_start) et0 <= 1'b1;
+end
+
+//------------------------------------------------------------------------------ dsp busy
+
+// The DSP busy flag is asserted when:
+// - A DSP command is being processed
+// - A DSP interrupt service routine is active (e.g., handling DMA or pause DAC)
+// - High-speed mode is active
+// - MIDI UART mode is active
+// - SB16 is idle (the SB16 dsp_busy flag toggles while waiting for new commands)
+wire dsp_busy = (dsp_busy_cnt > 0) || highspeed_mode || midi_uart_mode || (~sbp && dsp_busy_sb16_idle);
 
 // Games, such as The Secret to Monkey Island, have a compiled in CT-VOICE driver
 // that communicates to the DSP. When the driver knows a sound is currently playing,
@@ -653,37 +740,43 @@ end
 // To replicate the expected behavior the write port status will return busy when the
 // register is read the first time following a DMA request, and on subsequent reads it will
 // return idle.
-localparam S_DSP_BUSY_DURATION = 1'd1;
+localparam S_DSP_BUSY_DURATION = 2'd3; // 2 us up to 3 us should be detectable when polling on a 486 at 15 MHz
 
-// The fake busy signal communicates what the software using the sound card expects, and
-// does not mean the DSP module is actually busy.
-wire dsp_fake_busy = (dsp_busy_cnt > 0);
+wire dsp_busy_start = cmd_start || dma_req || pause_decrement;
 
-reg dsp_busy_cnt;
+reg [1:0] dsp_busy_cnt;
 always @(posedge clk) begin
-	if(rst_n == 1'b0)                dsp_busy_cnt <= 0;
-	else if(sw_reset)                dsp_busy_cnt <= 0;
+	if(!rst_n)                            dsp_busy_cnt <= 0;
+	else if(sw_reset)                     dsp_busy_cnt <= 0;
+
+	// Go busy for S_DSP_BUSY_DURATION on dsp_busy_start
+	else if(dsp_busy_start)               dsp_busy_cnt <= S_DSP_BUSY_DURATION;
 
 	// Go back to idle after countdown reaches 0
-	else if(ce_1us && dsp_fake_busy) dsp_busy_cnt <= dsp_busy_cnt - 1'd1;
-
-	// Go busy when a DMA request is made.
-	else if(dma_req) begin
-		dsp_busy_cnt <= S_DSP_BUSY_DURATION;
-	end
+	else if(ce_1us && (dsp_busy_cnt > 0)) dsp_busy_cnt <= dsp_busy_cnt - 1'd1;
 end
+
+// Real SB16 DSP Idle: dsp_busy HIGH for 0.5 us, LOW for 3.5 us per 4 us cycle (250 kHz)
+reg [1:0] dsp_busy_sb16_idle_cnt;
+always @(posedge clk) begin
+	if(!rst_n)       dsp_busy_sb16_idle_cnt <= 2'd0;
+	else if(ce_1us)  dsp_busy_sb16_idle_cnt <= dsp_busy_sb16_idle_cnt + 1'd1;
+end
+wire dsp_busy_sb16_idle = (dsp_busy_sb16_idle_cnt == 0);
+
+//------------------------------------------------------------------------------
 
 reg [3:0] dma_format; // 16/8, sbp_stereo/mono, sb16_stereo/mono, signed/unsigned
 always @(posedge clk) begin
-	if(~rst_n || sw_reset)                     dma_format <= 0;
+	if(!rst_n || sw_reset)                     dma_format <= 0;
 	else if(dma_new_start)                     dma_format <= {cmd_curr[4], 1'b0, write_buffer[21:20]};
-	else if(dma_single_start | dma_auto_start) dma_format <= {1'b0, sbp_stereo, 2'b00};
+	else if(dma_single_start | dma_auto_start) dma_format <= {1'b0, sbp_stereo, 1'b0, 1'b0};
 end
 
-reg sbp_lr;
+reg sbp_lr; // this flip-flop is actually inside the mixer IC and not the DSP
 always @(posedge clk) begin
-	if(dma_single_start|dma_auto_start) sbp_lr <= 0;
-	else if(sample_output)              sbp_lr <= ~sbp_lr;
+	if(!rst_n || sbp_stereo_ff_rst) sbp_lr <= 1'b1; // first sample to right channel compensates for SBPro PCB L/R swap
+	else if(sample_output)          sbp_lr <= ~sbp_lr;
 end
 
 wire   dma_16_req = dma_format[3];
@@ -723,95 +816,95 @@ localparam [1:0] ADPCM_3BIT = 2'd2;
 localparam [1:0] ADPCM_2BIT = 2'd3;
 
 wire adpcm_reference_start = 
-    (dma_single_start || dma_auto_start) && (
-    dma_command == S_OUT_SINGLE_2_BIT_REF || dma_command == S_OUT_SINGLE_3_BIT_REF || dma_command == S_OUT_SINGLE_4_BIT_REF ||
-    dma_command == S_OUT_AUTO_2_BIT_REF   || dma_command == S_OUT_AUTO_3_BIT_REF   || dma_command == S_OUT_AUTO_4_BIT_REF
+	(dma_single_start || dma_auto_start) && (
+	dma_command == S_OUT_SINGLE_2_BIT_REF || dma_command == S_OUT_SINGLE_3_BIT_REF || dma_command == S_OUT_SINGLE_4_BIT_REF ||
+	dma_command == S_OUT_AUTO_2_BIT_REF   || dma_command == S_OUT_AUTO_3_BIT_REF   || dma_command == S_OUT_AUTO_4_BIT_REF
 );
 
-wire adpcm_output = !dma_wait && adpcm_wait;
+wire adpcm_output = timer_0_isr && adpcm_wait;
 
 reg adpcm_reference_awaiting;
 always @(posedge clk) begin
-    if(rst_n == 1'b0)                               adpcm_reference_awaiting <= 1'b0;
-    else if(sw_reset)                               adpcm_reference_awaiting <= 1'b0;
-    else if(adpcm_reference_start)                  adpcm_reference_awaiting <= 1'b1;
-    else if(dma_single_start || dma_auto_start)     adpcm_reference_awaiting <= 1'b0;
-    else if(adpcm_reference_awaiting && dma_output) adpcm_reference_awaiting <= 1'b0;
-    else if(dma_finished)                           adpcm_reference_awaiting <= 1'b0;
+	if(!rst_n)                                      adpcm_reference_awaiting <= 1'b0;
+	else if(sw_reset)                               adpcm_reference_awaiting <= 1'b0;
+	else if(adpcm_reference_start)                  adpcm_reference_awaiting <= 1'b1;
+	else if(dma_single_start || dma_auto_start)     adpcm_reference_awaiting <= 1'b0;
+	else if(adpcm_reference_awaiting && dma_output) adpcm_reference_awaiting <= 1'b0;
+	else if(dma_finished)                           adpcm_reference_awaiting <= 1'b0;
 end
 
 reg adpcm_reference_output;
 always @(posedge clk) begin
-    if(rst_n == 1'b0)   adpcm_reference_output <= 1'b0;
-    else                adpcm_reference_output <= adpcm_reference_awaiting;
+	if(!rst_n)          adpcm_reference_output <= 1'b0;
+	else                adpcm_reference_output <= adpcm_reference_awaiting;
 end
 
 reg [1:0] adpcm_wait;
 always @(posedge clk) begin
-    if(rst_n == 1'b0)                               adpcm_wait <= 2'd0;
-    else if(sw_reset)                               adpcm_wait <= 2'd0;
-    else if(dma_single_start || dma_auto_start)     adpcm_wait <= 2'd0;
-    else if(adpcm_reference_awaiting && dma_output) adpcm_wait <= 2'd0;
-    else if(dma_output && adpcm_type == ADPCM_2BIT) adpcm_wait <= 2'd3;
-    else if(dma_output && adpcm_type == ADPCM_3BIT) adpcm_wait <= 2'd2;
-    else if(dma_output && adpcm_type == ADPCM_4BIT) adpcm_wait <= 2'd1;
-    else if(adpcm_output && adpcm_wait > 2'd0)      adpcm_wait <= adpcm_wait - 2'd1;
+	if(!rst_n)                                      adpcm_wait <= 2'd0;
+	else if(sw_reset)                               adpcm_wait <= 2'd0;
+	else if(dma_single_start || dma_auto_start)     adpcm_wait <= 2'd0;
+	else if(adpcm_reference_awaiting && dma_output) adpcm_wait <= 2'd0;
+	else if(dma_output && adpcm_type == ADPCM_2BIT) adpcm_wait <= 2'd3;
+	else if(dma_output && adpcm_type == ADPCM_3BIT) adpcm_wait <= 2'd2;
+	else if(dma_output && adpcm_type == ADPCM_4BIT) adpcm_wait <= 2'd1;
+	else if(adpcm_output && adpcm_wait > 2'd0)      adpcm_wait <= adpcm_wait - 2'd1;
 end
 
 reg [7:0] adpcm_sample;
 always @(posedge clk) begin
-    if(rst_n == 1'b0)                                   adpcm_sample <= 8'd0;
-    else if(sw_reset)                                   adpcm_sample <= 8'd0;
-    else if(dma_output)                                 adpcm_sample <= dma_readdata[7:0];
-    else if(adpcm_output && adpcm_type == ADPCM_2BIT)   adpcm_sample <= { adpcm_sample[5:0], 2'b0 };
-    else if(adpcm_output && adpcm_type == ADPCM_3BIT)   adpcm_sample <= { adpcm_sample[4:0], 3'b0 };
-    else if(adpcm_output && adpcm_type == ADPCM_4BIT)   adpcm_sample <= { adpcm_sample[3:0], 4'b0 };
+	if(!rst_n)                                          adpcm_sample <= 8'd0;
+	else if(sw_reset)                                   adpcm_sample <= 8'd0;
+	else if(dma_output)                                 adpcm_sample <= dma_readdata[7:0];
+	else if(adpcm_output && adpcm_type == ADPCM_2BIT)   adpcm_sample <= { adpcm_sample[5:0], 2'b0 };
+	else if(adpcm_output && adpcm_type == ADPCM_3BIT)   adpcm_sample <= { adpcm_sample[4:0], 3'b0 };
+	else if(adpcm_output && adpcm_type == ADPCM_4BIT)   adpcm_sample <= { adpcm_sample[3:0], 4'b0 };
 end
 
 reg adpcm_active;
 always @(posedge clk) begin
-    if(rst_n == 1'b0)                                   adpcm_active <= 1'b0;
-    else if(sw_reset)                                   adpcm_active <= 1'b0;
-    else if(adpcm_reference_awaiting && dma_output)     adpcm_active <= 1'b0;
-    else if(adpcm_type != ADPCM_NONE && dma_output)     adpcm_active <= 1'b1;
-    else if(adpcm_output)                               adpcm_active <= 1'b1;
-    else                                                adpcm_active <= 1'b0;
+	if(!rst_n)                                          adpcm_active <= 1'b0;
+	else if(sw_reset)                                   adpcm_active <= 1'b0;
+	else if(adpcm_reference_awaiting && dma_output)     adpcm_active <= 1'b0;
+	else if(adpcm_type != ADPCM_NONE && dma_output)     adpcm_active <= 1'b1;
+	else if(adpcm_output)                               adpcm_active <= 1'b1;
+	else                                                adpcm_active <= 1'b0;
 end
 
 wire [7:0] adpcm_active_value =
-    (adpcm_type == ADPCM_2BIT)?     adpcm_2bit_reference_next :
-    (adpcm_type == ADPCM_3BIT)?     adpcm_3bit_reference_next :
-                                    adpcm_4bit_reference_next;
+	(adpcm_type == ADPCM_2BIT)?     adpcm_2bit_reference_next :
+	(adpcm_type == ADPCM_3BIT)?     adpcm_3bit_reference_next :
+	                                adpcm_4bit_reference_next;
 
 reg [1:0] adpcm_type;
 always @(posedge clk) begin
-    if(rst_n == 1'b0)                                                                                                                                                       adpcm_type <= ADPCM_NONE;
-    else if(sw_reset)                                                                                                                                                       adpcm_type <= ADPCM_NONE;
-    else if((dma_single_start || dma_auto_start) && (dma_command == S_OUT_SINGLE_2_BIT_REF || dma_command == S_OUT_SINGLE_2_BIT || dma_command == S_OUT_AUTO_2_BIT_REF))    adpcm_type <= ADPCM_2BIT;
-    else if((dma_single_start || dma_auto_start) && (dma_command == S_OUT_SINGLE_3_BIT_REF || dma_command == S_OUT_SINGLE_3_BIT || dma_command == S_OUT_AUTO_3_BIT_REF))    adpcm_type <= ADPCM_3BIT;
-    else if((dma_single_start || dma_auto_start) && (dma_command == S_OUT_SINGLE_4_BIT_REF || dma_command == S_OUT_SINGLE_4_BIT || dma_command == S_OUT_AUTO_4_BIT_REF))    adpcm_type <= ADPCM_4BIT;
-    else if((dma_single_start || dma_auto_start))                                                                                                                           adpcm_type <= ADPCM_NONE;
-    else if(dma_finished)                                                                                                                                                   adpcm_type <= ADPCM_NONE;
+	if(!rst_n)                                                                                                                                                              adpcm_type <= ADPCM_NONE;
+	else if(sw_reset)                                                                                                                                                       adpcm_type <= ADPCM_NONE;
+	else if((dma_single_start || dma_auto_start) && (dma_command == S_OUT_SINGLE_2_BIT_REF || dma_command == S_OUT_SINGLE_2_BIT || dma_command == S_OUT_AUTO_2_BIT_REF))    adpcm_type <= ADPCM_2BIT;
+	else if((dma_single_start || dma_auto_start) && (dma_command == S_OUT_SINGLE_3_BIT_REF || dma_command == S_OUT_SINGLE_3_BIT || dma_command == S_OUT_AUTO_3_BIT_REF))    adpcm_type <= ADPCM_3BIT;
+	else if((dma_single_start || dma_auto_start) && (dma_command == S_OUT_SINGLE_4_BIT_REF || dma_command == S_OUT_SINGLE_4_BIT || dma_command == S_OUT_AUTO_4_BIT_REF))    adpcm_type <= ADPCM_4BIT;
+	else if((dma_single_start || dma_auto_start))                                                                                                                           adpcm_type <= ADPCM_NONE;
+	else if(dma_finished)                                                                                                                                                   adpcm_type <= ADPCM_NONE;
 end
 
 reg [2:0] adpcm_step;
 always @(posedge clk) begin
-    if(rst_n == 1'b0)                                   adpcm_step <= 3'd0;
-    else if(sw_reset)                                   adpcm_step <= 3'd0;
-    else if(adpcm_active && adpcm_type == ADPCM_2BIT)   adpcm_step <= adpcm_2bit_step_next;
-    else if(adpcm_active && adpcm_type == ADPCM_3BIT)   adpcm_step <= adpcm_3bit_step_next;
-    else if(adpcm_active && adpcm_type == ADPCM_4BIT)   adpcm_step <= adpcm_4bit_step_next;
-    else if(adpcm_reference_awaiting && dma_output)     adpcm_step <= 3'd0;
+	if(!rst_n)                                          adpcm_step <= 3'd0;
+	else if(sw_reset)                                   adpcm_step <= 3'd0;
+	else if(adpcm_active && adpcm_type == ADPCM_2BIT)   adpcm_step <= adpcm_2bit_step_next;
+	else if(adpcm_active && adpcm_type == ADPCM_3BIT)   adpcm_step <= adpcm_3bit_step_next;
+	else if(adpcm_active && adpcm_type == ADPCM_4BIT)   adpcm_step <= adpcm_4bit_step_next;
+	else if(adpcm_reference_awaiting && dma_output)     adpcm_step <= 3'd0;
 end
 
 reg [7:0] adpcm_reference;
 always @(posedge clk) begin
-    if(rst_n == 1'b0)                                   adpcm_reference <= 8'd0;
-    else if(sw_reset)                                   adpcm_reference <= 8'd0;
-    else if(adpcm_active && adpcm_type == ADPCM_2BIT)   adpcm_reference <= adpcm_2bit_reference_next;
-    else if(adpcm_active && adpcm_type == ADPCM_3BIT)   adpcm_reference <= adpcm_3bit_reference_next;
-    else if(adpcm_active && adpcm_type == ADPCM_4BIT)   adpcm_reference <= adpcm_4bit_reference_next;
-    else if(adpcm_reference_awaiting && dma_output)     adpcm_reference <= dma_readdata[7:0];
+	if(!rst_n)                                          adpcm_reference <= 8'd0;
+	else if(sw_reset)                                   adpcm_reference <= 8'd0;
+	else if(adpcm_active && adpcm_type == ADPCM_2BIT)   adpcm_reference <= adpcm_2bit_reference_next;
+	else if(adpcm_active && adpcm_type == ADPCM_3BIT)   adpcm_reference <= adpcm_3bit_reference_next;
+	else if(adpcm_active && adpcm_type == ADPCM_4BIT)   adpcm_reference <= adpcm_4bit_reference_next;
+	else if(adpcm_reference_awaiting && dma_output)     adpcm_reference <= dma_readdata[7:0];
 end
 
 //------------------------------------------------------------------------------ adpcm 2 bit
@@ -819,82 +912,90 @@ end
 wire [1:0] adpcm_2bit_sample = adpcm_sample[7:6];
 
 wire [7:0] adpcm_2bit_reference_adjust =
-    (adpcm_step[2:0] == 3'd0)?      { 7'd0, adpcm_2bit_sample[0] } :
-    (adpcm_step[2:0] == 3'd1)?      { 6'd0, adpcm_2bit_sample[0], 1'b1 } :
-    (adpcm_step[2:0] == 3'd2)?      { 5'd0, adpcm_2bit_sample[0], 2'b10 } :
-    (adpcm_step[2:0] == 3'd3)?      { 4'd0, adpcm_2bit_sample[0], 3'b100 } :
-    (adpcm_step[2:0] == 3'd4)?      { 3'd0, adpcm_2bit_sample[0], 4'b1000 } :
-                                    { 2'd0, adpcm_2bit_sample[0], 5'b10000 }; //adpcm_step[2:0] == 3'd5
+	(adpcm_step[2:0] == 3'd0)?      { 7'd0, adpcm_2bit_sample[0] } :
+	(adpcm_step[2:0] == 3'd1)?      { 6'd0, adpcm_2bit_sample[0], 1'b1 } :
+	(adpcm_step[2:0] == 3'd2)?      { 5'd0, adpcm_2bit_sample[0], 2'b10 } :
+	(adpcm_step[2:0] == 3'd3)?      { 4'd0, adpcm_2bit_sample[0], 3'b100 } :
+	(adpcm_step[2:0] == 3'd4)?      { 3'd0, adpcm_2bit_sample[0], 4'b1000 } :
+	                                { 2'd0, adpcm_2bit_sample[0], 5'b10000 }; //adpcm_step[2:0] == 3'd5
 
 wire [8:0] adpcm_2bit_reference_sum = adpcm_reference + adpcm_2bit_reference_adjust;
 wire [8:0] adpcm_2bit_reference_sub = adpcm_reference - adpcm_2bit_reference_adjust;
 
 wire [7:0] adpcm_2bit_reference_next =
-    (adpcm_2bit_sample[1] && adpcm_2bit_reference_sub[8])?  8'd0 :
-    (adpcm_2bit_sample[1])?                                 adpcm_2bit_reference_sub[7:0] :
-    (adpcm_2bit_reference_sum[8])?                          8'd255 :
-                                                            adpcm_2bit_reference_sum[7:0];
+	(adpcm_2bit_sample[1] && adpcm_2bit_reference_sub[8])?  8'd0 :
+	(adpcm_2bit_sample[1])?                                 adpcm_2bit_reference_sub[7:0] :
+	(adpcm_2bit_reference_sum[8])?                          8'd255 :
+	                                                        adpcm_2bit_reference_sum[7:0];
 wire [2:0] adpcm_2bit_step_next =
-    (adpcm_step < 3'd5 && adpcm_2bit_sample[0] == 1'b1)?    adpcm_step + 3'd1 :
-    (adpcm_step > 3'd0 && adpcm_2bit_sample[0] == 1'b0)?    adpcm_step - 3'd1 :
-                                                            adpcm_step;
+	(adpcm_step < 3'd5 && adpcm_2bit_sample[0] == 1'b1)?    adpcm_step + 3'd1 :
+	(adpcm_step > 3'd0 && adpcm_2bit_sample[0] == 1'b0)?    adpcm_step - 3'd1 :
+	                                                        adpcm_step;
 
 //------------------------------------------------------------------------------ adpcm 3 bit
 
 wire [2:0] adpcm_3bit_sample = adpcm_sample[7:5];
 
 wire [7:0] adpcm_3bit_reference_adjust =
-    (adpcm_step[2:0] == 3'd0)?                                  { 6'd0, adpcm_3bit_sample[1:0] } :
-    (adpcm_step[2:0] == 3'd1)?                                  { 5'd0, adpcm_3bit_sample[1:0], 1'b1 } :
-    (adpcm_step[2:0] == 3'd2)?                                  { 4'd0, adpcm_3bit_sample[1:0], 2'b10 } :
-    (adpcm_step[2:0] == 3'd3)?                                  { 3'd0, adpcm_3bit_sample[1:0], 3'b100 } :
-    (adpcm_step[2:0] == 3'd4 && adpcm_3bit_sample == 3'd0)?     8'd5 :
-    (adpcm_step[2:0] == 3'd4 && adpcm_3bit_sample == 3'd1)?     8'd15 :
-    (adpcm_step[2:0] == 3'd4 && adpcm_3bit_sample == 3'd2)?     8'd25 :
-                                                                8'd35;
-    
+	(adpcm_step[2:0] == 3'd0)?                                  { 6'd0, adpcm_3bit_sample[1:0] } :
+	(adpcm_step[2:0] == 3'd1)?                                  { 5'd0, adpcm_3bit_sample[1:0], 1'b1 } :
+	(adpcm_step[2:0] == 3'd2)?                                  { 4'd0, adpcm_3bit_sample[1:0], 2'b10 } :
+	(adpcm_step[2:0] == 3'd3)?                                  { 3'd0, adpcm_3bit_sample[1:0], 3'b100 } :
+	(adpcm_step[2:0] == 3'd4 && adpcm_3bit_sample == 3'd0)?     8'd5 :
+	(adpcm_step[2:0] == 3'd4 && adpcm_3bit_sample == 3'd1)?     8'd15 :
+	(adpcm_step[2:0] == 3'd4 && adpcm_3bit_sample == 3'd2)?     8'd25 :
+	                                                            8'd35;
+
 wire [8:0] adpcm_3bit_reference_sum = adpcm_reference + adpcm_3bit_reference_adjust;
 wire [8:0] adpcm_3bit_reference_sub = adpcm_reference - adpcm_3bit_reference_adjust;
 
 wire [7:0] adpcm_3bit_reference_next =
-    (adpcm_3bit_sample[2] && adpcm_3bit_reference_sub[8])?  8'd0 :
-    (adpcm_3bit_sample[2])?                                 adpcm_3bit_reference_sub[7:0] :
-    (adpcm_3bit_reference_sum[8])?                          8'd255 :
-                                                            adpcm_3bit_reference_sum[7:0];
+	(adpcm_3bit_sample[2] && adpcm_3bit_reference_sub[8])?  8'd0 :
+	(adpcm_3bit_sample[2])?                                 adpcm_3bit_reference_sub[7:0] :
+	(adpcm_3bit_reference_sum[8])?                          8'd255 :
+	                                                        adpcm_3bit_reference_sum[7:0];
 wire [2:0] adpcm_3bit_step_next =
-    (adpcm_step < 3'd4 && adpcm_3bit_sample[1:0] == 2'b11)? adpcm_step + 3'd1 :
-    (adpcm_step > 3'd0 && adpcm_3bit_sample[1:0] == 2'b00)? adpcm_step - 3'd1 :
-                                                            adpcm_step;
+	(adpcm_step < 3'd4 && adpcm_3bit_sample[1:0] == 2'b11)? adpcm_step + 3'd1 :
+	(adpcm_step > 3'd0 && adpcm_3bit_sample[1:0] == 2'b00)? adpcm_step - 3'd1 :
+	                                                        adpcm_step;
 
 //------------------------------------------------------------------------------ adpcm 4 bit
 
 wire [3:0] adpcm_4bit_sample = adpcm_sample[7:4];
 
 wire [7:0] adpcm_4bit_reference_adjust =
-    (adpcm_step[2:0] == 3'd0)?      { 5'd0, adpcm_4bit_sample[2:0] } :
-    (adpcm_step[2:0] == 3'd1)?      { 4'd0, adpcm_4bit_sample[2:0], 1'b1 } :
-    (adpcm_step[2:0] == 3'd2)?      { 3'd0, adpcm_4bit_sample[2:0], 2'b10 } :
-                                    { 2'd0, adpcm_4bit_sample[2:0], 3'b100 }; //adpcm_step[2:0] == 3'd3
-    
+	(adpcm_step[2:0] == 3'd0)?      { 5'd0, adpcm_4bit_sample[2:0] } :
+	(adpcm_step[2:0] == 3'd1)?      { 4'd0, adpcm_4bit_sample[2:0], 1'b1 } :
+	(adpcm_step[2:0] == 3'd2)?      { 3'd0, adpcm_4bit_sample[2:0], 2'b10 } :
+	                                { 2'd0, adpcm_4bit_sample[2:0], 3'b100 }; //adpcm_step[2:0] == 3'd3
+
 wire [8:0] adpcm_4bit_reference_sum = adpcm_reference + adpcm_4bit_reference_adjust;
 wire [8:0] adpcm_4bit_reference_sub = adpcm_reference - adpcm_4bit_reference_adjust;
 
 wire [7:0] adpcm_4bit_reference_next =
-    (adpcm_4bit_sample[3] && adpcm_4bit_reference_sub[8])?  8'd0 :
-    (adpcm_4bit_sample[3])?                                 adpcm_4bit_reference_sub[7:0] :
-    (adpcm_4bit_reference_sum[8])?                          8'd255 :
-                                                            adpcm_4bit_reference_sum[7:0];
+	(adpcm_4bit_sample[3] && adpcm_4bit_reference_sub[8])?  8'd0 :
+	(adpcm_4bit_sample[3])?                                 adpcm_4bit_reference_sub[7:0] :
+	(adpcm_4bit_reference_sum[8])?                          8'd255 :
+	                                                        adpcm_4bit_reference_sum[7:0];
 wire [2:0] adpcm_4bit_step_next =
-    (adpcm_step < 3'd3 && adpcm_4bit_sample[2:0] >= 3'd5)?  adpcm_step + 3'd1 :
-    (adpcm_step > 3'd0 && adpcm_4bit_sample[2:0] == 3'd0)?  adpcm_step - 3'd1 :
-                                                            adpcm_step;
+	(adpcm_step < 3'd3 && adpcm_4bit_sample[2:0] >= 3'd5)?  adpcm_step + 3'd1 :
+	(adpcm_step > 3'd0 && adpcm_4bit_sample[2:0] == 3'd0)?  adpcm_step - 3'd1 :
+	                                                        adpcm_step;
 
 //------------------------------------------------------------------------------
 
 wire [15:0] sample =
-    (adpcm_reference_output)?   {adpcm_sample, adpcm_sample} :
-    (adpcm_active)?             {adpcm_active_value, adpcm_active_value} :
-                                {write_buffer[7:0], write_buffer[7:0]};
+	(adpcm_reference_output)?   {adpcm_sample, adpcm_sample} :
+	(adpcm_active)?             {adpcm_active_value, adpcm_active_value} :
+	                            {write_buffer[7:0], write_buffer[7:0]};
+
+// Signed samples
+wire [15:0] sample_dma_l = {            sample_dma[0][15] ^ ~dma_format[0],             sample_dma[0][14:0]};
+wire [15:0] sample_dma_r = {sample_dma[dma_format[1]][15] ^ ~dma_format[0], sample_dma[dma_format[1]][14:0]};
+
+// Attenuation should not be needed
+//wire [15:0] sample_dma_l_attenuated = {sample_dma_l[15], sample_dma_l[15:1]}; // (-6dB)
+//wire [15:0] sample_dma_r_attenuated = {sample_dma_r[15], sample_dma_r[15:1]}; // (-6dB)
 
 always @(posedge clk) begin
 	if((~speaker_on & sbp) | pause_active) begin
@@ -903,12 +1004,13 @@ always @(posedge clk) begin
 	end
 	else if(sample_output && adpcm_type == ADPCM_NONE) begin
 		if(dma_format[2]) begin
-			if(~sbp_lr) sample_value_l <= {sample_dma[0][15] ^ ~dma_format[0], sample_dma[0][14:0]};
-			else        sample_value_r <= {sample_dma[0][15] ^ ~dma_format[0], sample_dma[0][14:0]};
+			// SBPro stereo (interleaved)
+			if(~sbp_lr) sample_value_l <= sample_dma_l;
+			else        sample_value_r <= sample_dma_l;
 		end
 		else begin
-			sample_value_l <= {            sample_dma[0][15] ^ ~dma_format[0],            sample_dma[0][14:0]};
-			sample_value_r <= {sample_dma[dma_format[1]][15] ^ ~dma_format[0], sample_dma[dma_format[1]][14:0]};
+			sample_value_l <= sample_dma_l;
+			sample_value_r <= sample_dma_r;
 		end
 	end
 	else if(cmd_direct_output | adpcm_active | (~adpcm_reference_awaiting & adpcm_reference_output)) begin
@@ -916,7 +1018,7 @@ always @(posedge clk) begin
 		sample_value_r <= {~sample[15], sample[14:0]};
 	end
 end
-	
+
 //------------------------------------------------------------------------------
 
 endmodule

--- a/rtl/system.v
+++ b/rtl/system.v
@@ -39,7 +39,7 @@ module system
 	output        ps2_reset_n,
 
 	input   [5:0] bootcfg,
-  input         uma_ram,
+	input         uma_ram,
 	output  [7:0] syscfg,
 
 	input         clk_uart1,
@@ -65,6 +65,8 @@ module system
 	output        mpu_tx,
 
 	input         clk_audio,
+	output  [8:0] sample_cms_l,
+	output  [8:0] sample_cms_r,
 	output [15:0] sample_sb_l,
 	output [15:0] sample_sb_r,
 	output [15:0] sample_opl_l,
@@ -74,12 +76,16 @@ module system
 
 	output        speaker_out,
 
-	output  [4:0] vol_l,
-	output  [4:0] vol_r,
-	output  [4:0] vol_cd_l,
-	output  [4:0] vol_cd_r,
+	output        sbp,
+
+	output  [4:0] vol_master_l,
+	output  [4:0] vol_master_r,
+	output  [4:0] vol_voice_l,
+	output  [4:0] vol_voice_r,
 	output  [4:0] vol_midi_l,
 	output  [4:0] vol_midi_r,
+	output  [4:0] vol_cd_l,
+	output  [4:0] vol_cd_r,
 	output  [4:0] vol_line_l,
 	output  [4:0] vol_line_r,
 	output  [1:0] vol_spk,
@@ -657,19 +663,25 @@ sound sound
 	.dma_readdata      (dma_sb_req_16 ? dma_sb_readdata_16 : dma_sb_readdata_8),
 	.dma_writedata     (dma_sb_writedata),
 
-	.vol_l             (vol_l),
-	.vol_r             (vol_r),
-	.vol_cd_l          (vol_cd_l),
-	.vol_cd_r          (vol_cd_r),
+	.sbp               (sbp),
+
+	.vol_master_l      (vol_master_l),
+	.vol_master_r      (vol_master_r),
+	.vol_voice_l       (vol_voice_l),
+	.vol_voice_r       (vol_voice_r),
 	.vol_midi_l        (vol_midi_l),
 	.vol_midi_r        (vol_midi_r),
+	.vol_cd_l          (vol_cd_l),
+	.vol_cd_r          (vol_cd_r),
 	.vol_line_l        (vol_line_l),
 	.vol_line_r        (vol_line_r),
 	.vol_spk           (vol_spk),
 	.vol_en            (vol_en),
 
-	.sample_l          (sample_sb_l),
-	.sample_r          (sample_sb_r),
+	.sample_cms_l      (sample_cms_l),
+	.sample_cms_r      (sample_cms_r),
+	.sample_sb_l       (sample_sb_l),
+	.sample_sb_r       (sample_sb_r),
 	.sample_opl_l      (sample_opl_l),
 	.sample_opl_r      (sample_opl_r),
 


### PR DESCRIPTION
- Fix high-speed DMA mode (fixes e.g. Silverball and other games)
- Implemented DSP 8051 timer 0 logic
- Improved DSP busy flag logic (e.g. games and the Unreal demo) (see also #34, #88)
  The DSP busy flag is asserted when:
  - A DSP command is being processed
  - A DSP interrupt service routine is active (e.g., handling DMA or pause DAC)
  - High-speed mode is active
  - MIDI UART mode is active
  - SB16 is idle (the SB16 DSP busy flag toggles at 250 kHz while waiting for new commands)
- Fix Sound Blaster Pro stereo interleaving (Silverball/Unreal)
  Resetting the stereo interleaving flip-flop when the mixer register 0Eh is written results in SBPro hardware accurate behavior (see also: [SBPro1 CT1330A, lets solve the Reversed Stereo myth!](https://www.vogons.org/viewtopic.php?t=50539)).
- Add "SB Swap L/R" option that swaps SB DSP digital audio only (e.g. allows correct left/right flipper sound in Epic Pinball)
- Fix reserved bit values in mixer registers (fixes Sound Blaster Pro stereo detection for e.g. Epic Pinball, Jazz Jackrabbit)
  The Sound Blaster Series 16-bit MASI Driver v2.90 used in games like Epic Pinball (MDRV004R.MUS) and Jazz Jackrabbit (MDRV004D.MUS) writes the value F3h to the mixer's master volume register (22h), then reads it back to verify. Stereo playback is enabled only if the returned value matches what was written. Hence, the reserved bits 0 and 4 in the volume registers 04h, 22h, 26h, 28h, 2Eh must be output like the original Sound Blaster Pro does (value 1) to ensure correct stereo detection with this driver.
- Add mic volume register 0Ah (fixes Sound Blaster Pro detection for e.g. Ultima Underworld, Dune II and others)
  `SBPDIG.ADV` performs a read-modify-write check on the mixer's mic volume register 0Ah as part of the Sound Blaster Pro detection routine.
- Add other missing CT1345/CT1745 mixer registers in case some games check for these
- Add SBPro/SB16 volume curves (uses 1 DSP block and applies volume sequentially for the channels Master/Voice/MIDI/CD/MT-32)
  SBPro:  8 volume levels (3-bit), -46 dB, -28, -22, -16, -11, -7, -3, 0 dB
  SB16:  32 volume levels (5-bit), -62 dB to 0 dB, in 2 dB steps
- Improved CT1345/CT1745 (legacy) volume register handling
  The SB16 legacy 4-bit volume levels map into the 32 level SB16 volume curve: -60 dB to 0 dB, in 4 dB steps
- Reduced Master/Voice/MIDI/CD/Line default volume from 31 to 29 for increased headroom (see also #54)
- Refactor and add comments to improve code clarity and maintainability.

---

**Sound Blaster Pro**
```
C:\MISTER\SBCTL.EXE T4
SET BLASTER=A220 I5 D1 T4
```

**Sound Blaster 16**
```
C:\MISTER\SBCTL.EXE T6
SET BLASTER=A220 I5 D1 H5 T6
```