### PR TITLE
Second mouse support

### DIFF
--- a/ao486.sv
+++ b/ao486.sv
@@ -45,7 +45,8 @@ led fdd_led(clk_sys, |mgmt_req[7:6], LED_USER);
 // 0         1         2         3          4         5         6
 // 01234567890123456789012345678901 23456789012345678901234567890123
 // 0123456789ABCDEFGHIJKLMNOPQRSTUV 0123456789ABCDEFGHIJKLMNOPQRSTUV
-// XXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXX XXXXXXXXXXXXXXXXXXXXXXXXXXXX
+// XXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXX XXXXXXXXXXXXXXXXXXXXXXXXXXXXXXX
+//                                  (bits 60-62 = 2nd Mouse Port)
 
 `include "build_id.v"
 localparam CONF_STR =
@@ -100,6 +101,7 @@ localparam CONF_STR =
 `endif
 	"P2-;",
 	"P2OA,USER I/O,MIDI,COM2;",
+	"P2oSU,2nd Mouse Port,Off,COM1,COM2,COM3,COM4;",
 	"P2-;",
 	"P2OCD,Joystick Type,2 Buttons,4 Buttons,Gravis Pro,None;",
 	"P2oFG,Joystick Mode,2 Joysticks,2 Sticks,2 Wheels,4-axes Wheel;",
@@ -159,6 +161,9 @@ wire        mouse2_stb;
 
 wire  [1:0] buttons;
 wire [63:0] status;
+
+// 2nd-mouse target COM port (OSD "2nd Mouse Port"): 0=Off 1=COM1 2=COM2 3=COM3 4=COM4
+wire  [2:0] mouse2_com = status[62:60];
 
 wire [13:0] joystick_0;
 wire [13:0] joystick_1;
@@ -698,6 +703,7 @@ system system
 	.mouse2_dy            (mouse2_dy),
 	.mouse2_btn           (mouse2_btn[2:0]),
 	.mouse2_stb           (mouse2_stb),
+	.mouse2_com           (mouse2_com),
 
 	.mpu_rx               (mpu_rx),
 	.mpu_tx               (mpu_tx),

--- a/ao486.sv
+++ b/ao486.sv
@@ -151,6 +151,12 @@ wire        ps2_mouse_data_out;
 wire        ps2_mouse_clk_in;
 wire        ps2_mouse_data_in;
 
+// 2nd mouse (COM3 serial mouse) delivered by hps_io UIO 0x07
+wire  [7:0] mouse2_dx;
+wire  [7:0] mouse2_dy;
+wire  [7:0] mouse2_btn;
+wire        mouse2_stb;
+
 wire  [1:0] buttons;
 wire [63:0] status;
 
@@ -180,6 +186,11 @@ hps_io #(.CONF_STR(CONF_STR), .CONF_STR_BRAM(0), .PS2DIV(2000), .PS2WE(1), .WIDE
 	.ps2_mouse_data_out(ps2_mouse_data_out),
 	.ps2_mouse_clk_in(ps2_mouse_clk_in),
 	.ps2_mouse_data_in(ps2_mouse_data_in),
+
+	.mouse2_dx(mouse2_dx),
+	.mouse2_dy(mouse2_dy),
+	.mouse2_btn(mouse2_btn),
+	.mouse2_stb(mouse2_stb),
 
 	.buttons(buttons),
 	.status(status),
@@ -682,6 +693,11 @@ system system
 	.uart2_dsr_n          (uart2_dsr),
 	.uart2_rts_n          (uart2_rts),
 	.uart2_dtr_n          (uart2_dtr),
+
+	.mouse2_dx            (mouse2_dx),
+	.mouse2_dy            (mouse2_dy),
+	.mouse2_btn           (mouse2_btn[2:0]),
+	.mouse2_stb           (mouse2_stb),
 
 	.mpu_rx               (mpu_rx),
 	.mpu_tx               (mpu_tx),

--- a/files.qip
+++ b/files.qip
@@ -3,6 +3,7 @@ set_global_assignment -name QIP_FILE rtl/pll2.qip
 set_global_assignment -name QIP_FILE rtl/ao486/ao486.qip
 set_global_assignment -name QIP_FILE rtl/cache/cache.qip
 set_global_assignment -name QIP_FILE rtl/soc/uart/uart.qip
+set_global_assignment -name VERILOG_FILE rtl/soc/uart/serial_mouse.v
 set_global_assignment -name QIP_FILE rtl/soc/sound/sound.qip
 set_global_assignment -name QIP_FILE rtl/common/common.qip
 set_global_assignment -name VERILOG_FILE rtl/soc/iobus.v

--- a/rtl/soc/uart/serial_mouse.v
+++ b/rtl/soc/uart/serial_mouse.v
@@ -21,12 +21,18 @@
 //   * Each byte framed as start(0) + 7 data bits (LSB first) + stop(1);
 //     idle line = 1 (mark).
 //
-// CLKS_PER_BIT = clk frequency / 1200.  clk = clk_sys = 90 MHz -> 75000.
-// (The receiving 16550 runs off the standard 1.8432 MHz baud clock with the
-//  driver's divisor, so both reference real-time 1200 baud and stay in sync.)
+// CLOCK: drive `clk` from the FIXED UART baud reference (clk_uart2, 1.8432 MHz),
+// NOT clk_sys. clk_sys is reconfigured at runtime by the ao486 CPU-speed
+// selector (15..100 MHz), which would shift the generated baud. The 16550
+// receiver samples one bit every 16*divisor br_clk cycles; for the DOS-standard
+// 1200-baud divisor (96) that is 16*96 = 1536 cycles, so CLKS_PER_BIT = 1536
+// makes each generated bit exactly one receive-bit wide on the same clock.
+//
+// rts/dtr/strobe (and the dx/dy/btn buses) originate in the clk_sys domain, so
+// they are brought across with 2-FF synchronizers below before edge detection.
 // ===========================================================================
 
-module serial_mouse #(parameter CLKS_PER_BIT = 75000)
+module serial_mouse #(parameter CLKS_PER_BIT = 1536)
 (
 	input              clk,
 	input              reset,
@@ -44,11 +50,14 @@ module serial_mouse #(parameter CLKS_PER_BIT = 75000)
 
 localparam S_IDLE = 1'b0, S_SEND = 1'b1;
 
-// ---- edge / event detect ----
+// ---- CDC: rts/dtr/strobe come from the clk_sys domain; 2-FF synchronize ----
+reg rts_m, rts_s, dtr_m, dtr_s, strobe_m, strobe_s;
+
+// ---- edge / event detect (on the synchronized signals) ----
 reg rts_d, dtr_d, strobe_d;
-wire rts_rise   = rts & ~rts_d;
-wire dtr_rise   = dtr & ~dtr_d;
-wire strobe_evt = strobe ^ strobe_d;
+wire rts_rise   = rts_s & ~rts_d;
+wire dtr_rise   = dtr_s & ~dtr_d;
+wire strobe_evt = strobe_s ^ strobe_d;
 
 // ---- pending work ----
 reg              id_pending;
@@ -85,6 +94,7 @@ endtask
 
 always @(posedge clk) begin
 	if (reset) begin
+		rts_m <= 0; rts_s <= 0; dtr_m <= 0; dtr_s <= 0; strobe_m <= 0; strobe_s <= 0;
 		rts_d <= 0; dtr_d <= 0; strobe_d <= 0;
 		id_pending <= 0; move_pending <= 0;
 		acc_x <= 0; acc_y <= 0; btn_l <= 0;
@@ -92,7 +102,12 @@ always @(posedge clk) begin
 		byte_idx <= 0; nbytes <= 0;
 	end
 	else begin
-		rts_d <= rts; dtr_d <= dtr; strobe_d <= strobe;
+		// 2-FF synchronizers (clk_sys -> this clk domain)
+		rts_m <= rts; rts_s <= rts_m;
+		dtr_m <= dtr; dtr_s <= dtr_m;
+		strobe_m <= strobe; strobe_s <= strobe_m;
+		// edge-detect delay taps on the synchronized signals
+		rts_d <= rts_s; dtr_d <= dtr_s; strobe_d <= strobe_s;
 
 		// driver asserted RTS/DTR -> emit Microsoft 'M' identification byte
 		if (rts_rise | dtr_rise) id_pending <= 1'b1;
@@ -115,7 +130,7 @@ always @(posedge clk) begin
 				load_byte(7'h4D);            // 'M'
 				state <= S_SEND;
 			end
-			else if (move_pending && rts) begin
+			else if (move_pending && rts_s) begin
 				move_pending <= 1'b0;
 				// build packet from current accumulators, then clear them
 				pkt1 <= {1'b0, acc_x[5:0]};

--- a/rtl/soc/uart/serial_mouse.v
+++ b/rtl/soc/uart/serial_mouse.v
@@ -130,7 +130,7 @@ always @(posedge clk) begin
 				load_byte(7'h4D);            // 'M'
 				state <= S_SEND;
 			end
-			else if (move_pending && rts_s) begin
+			else if (move_pending && (rts_s | dtr_s)) begin   // powered by RTS OR DTR
 				move_pending <= 1'b0;
 				// build packet from current accumulators, then clear them
 				pkt1 <= {1'b0, acc_x[5:0]};

--- a/rtl/soc/uart/serial_mouse.v
+++ b/rtl/soc/uart/serial_mouse.v
@@ -1,0 +1,159 @@
+// ===========================================================================
+// Microsoft serial-mouse byte-stream generator (for ao486 COM3).
+//
+// The 16550 UART core only accepts a single serial RX wire, so to present a
+// second mouse to DOS as a *serial* mouse we synthesize the classic 1200-baud
+// 7N1 Microsoft mouse protocol on that wire. A stock DOS serial-mouse driver
+// (e.g. CuteMouse `CTMOUSE /S3`) then detects and reads it like real hardware.
+//
+// Mouse-2 deltas arrive already accumulated-per-host-event from Main_MiSTer via
+// hps_io UIO command 0x07 as {dx, dy, buttons} plus a toggling strobe.
+//
+// Protocol emitted:
+//   * On RTS (or DTR) rising edge — the driver "powers/resets" the mouse during
+//     detection — emit the identification byte 'M' (0x4D) so the driver knows it
+//     is a Microsoft mouse.
+//   * On movement / button change emit a 3-byte packet:
+//        D1: 1 LB RB Y7 Y6 X7 X6    (bit6 = sync = 1)
+//        D2: 0 X5 X4 X3 X2 X1 X0
+//        D3: 0 Y5 Y4 Y3 Y2 Y1 Y0
+//     X/Y are signed 8-bit deltas (high 2 bits in D1, low 6 bits in D2/D3).
+//   * Each byte framed as start(0) + 7 data bits (LSB first) + stop(1);
+//     idle line = 1 (mark).
+//
+// CLKS_PER_BIT = clk frequency / 1200.  clk = clk_sys = 90 MHz -> 75000.
+// (The receiving 16550 runs off the standard 1.8432 MHz baud clock with the
+//  driver's divisor, so both reference real-time 1200 baud and stay in sync.)
+// ===========================================================================
+
+module serial_mouse #(parameter CLKS_PER_BIT = 75000)
+(
+	input              clk,
+	input              reset,
+
+	input              rts,      // COM3 RTS asserted (active high)
+	input              dtr,      // COM3 DTR asserted (active high)
+
+	input        [7:0] dx,       // signed delta X (accumulated host-side)
+	input        [7:0] dy,       // signed delta Y
+	input        [2:0] btn,      // [0]=left [1]=right [2]=middle
+	input              strobe,   // toggles on each new mouse-2 update
+
+	output reg         rx        // serial line into UART3 RX (idle = 1)
+);
+
+localparam S_IDLE = 1'b0, S_SEND = 1'b1;
+
+// ---- edge / event detect ----
+reg rts_d, dtr_d, strobe_d;
+wire rts_rise   = rts & ~rts_d;
+wire dtr_rise   = dtr & ~dtr_d;
+wire strobe_evt = strobe ^ strobe_d;
+
+// ---- pending work ----
+reg              id_pending;
+reg              move_pending;
+reg signed [7:0] acc_x, acc_y;
+reg        [2:0] btn_l;
+
+// ---- transmit engine ----
+reg        state;
+reg [16:0] bit_div;
+reg  [3:0] bit_idx;     // 0..8 (start + 7 data + stop)
+reg  [8:0] frame;       // {stop, data[6:0], start}
+reg  [1:0] byte_idx;    // current byte within the sequence
+reg  [1:0] nbytes;      // 1 (ID) or 3 (packet)
+reg  [6:0] pkt1, pkt2;  // 2nd/3rd packet bytes
+
+// sign-extended accumulate so the clamp sees the true sum
+wire signed [9:0] sum_x = $signed({{2{acc_x[7]}}, acc_x}) + $signed({{2{dx[7]}}, dx});
+wire signed [9:0] sum_y = $signed({{2{acc_y[7]}}, acc_y}) + $signed({{2{dy[7]}}, dy});
+
+function signed [7:0] clamp8(input signed [9:0] v);
+	clamp8 = (v >  10'sd127)  ?  8'sd127 :
+	         (v < -10'sd128)  ?  8'sh80  : v[7:0];  // 8'sh80 = -128 (avoids 8'sd128 overflow)
+endfunction
+
+task load_byte(input [6:0] b);
+	begin
+		frame   <= {1'b1, b, 1'b0};   // stop=1, 7 data, start=0
+		bit_idx <= 4'd0;
+		bit_div <= 17'd0;
+		rx      <= 1'b0;              // drive the start bit now
+	end
+endtask
+
+always @(posedge clk) begin
+	if (reset) begin
+		rts_d <= 0; dtr_d <= 0; strobe_d <= 0;
+		id_pending <= 0; move_pending <= 0;
+		acc_x <= 0; acc_y <= 0; btn_l <= 0;
+		state <= S_IDLE; rx <= 1'b1; bit_div <= 0; bit_idx <= 0;
+		byte_idx <= 0; nbytes <= 0;
+	end
+	else begin
+		rts_d <= rts; dtr_d <= dtr; strobe_d <= strobe;
+
+		// driver asserted RTS/DTR -> emit Microsoft 'M' identification byte
+		if (rts_rise | dtr_rise) id_pending <= 1'b1;
+
+		// accumulate motion / latch buttons on each new host update
+		if (strobe_evt) begin
+			acc_x        <= clamp8(sum_x);
+			acc_y        <= clamp8(sum_y);
+			btn_l        <= btn;
+			move_pending <= 1'b1;
+		end
+
+		case (state)
+		S_IDLE: begin
+			rx <= 1'b1;
+			if (id_pending) begin
+				id_pending <= 1'b0;
+				nbytes   <= 2'd1;
+				byte_idx <= 2'd0;
+				load_byte(7'h4D);            // 'M'
+				state <= S_SEND;
+			end
+			else if (move_pending && rts) begin
+				move_pending <= 1'b0;
+				// build packet from current accumulators, then clear them
+				pkt1 <= {1'b0, acc_x[5:0]};
+				pkt2 <= {1'b0, acc_y[5:0]};
+				acc_x <= 0; acc_y <= 0;
+				nbytes   <= 2'd3;
+				byte_idx <= 2'd0;
+				load_byte({1'b1, btn_l[0], btn_l[1], acc_y[7:6], acc_x[7:6]});
+				state <= S_SEND;
+			end
+		end
+
+		S_SEND: begin
+			if (bit_div == CLKS_PER_BIT-1) begin
+				bit_div <= 0;
+				if (bit_idx == 4'd8) begin
+					// stop bit just completed -> byte done
+					if (byte_idx == nbytes-1) begin
+						rx    <= 1'b1;
+						state <= S_IDLE;
+					end
+					else begin
+						byte_idx <= byte_idx + 1'b1;
+						if (byte_idx == 2'd0) load_byte(pkt1);
+						else                  load_byte(pkt2);
+					end
+				end
+				else begin
+					bit_idx <= bit_idx + 1'b1;
+					rx      <= frame[bit_idx + 1];
+				end
+			end
+			else begin
+				bit_div <= bit_div + 1'b1;
+			end
+		end
+		endcase
+	end
+end
+
+endmodule

--- a/rtl/system.v
+++ b/rtl/system.v
@@ -60,6 +60,12 @@ module system
 	output        uart2_rts_n,
 	output        uart2_dtr_n,
 
+	// 2nd mouse (delivered over hps_io UIO 0x07) -> COM3 serial-mouse generator
+	input   [7:0] mouse2_dx,
+	input   [7:0] mouse2_dy,
+	input   [2:0] mouse2_btn,
+	input         mouse2_stb,
+
 	input         clk_mpu,
 	input         mpu_rx,
 	output        mpu_tx,
@@ -196,6 +202,7 @@ reg         fm_cs;
 reg         sb_cs;
 reg         uart1_cs;
 reg         uart2_cs;
+reg         uart3_cs;
 reg         mpu_cs;
 reg         vga_b_cs;
 reg         vga_c_cs;
@@ -214,6 +221,11 @@ wire  [7:0] ps2_readdata;
 wire  [7:0] rtc_readdata;
 wire  [7:0] uart1_readdata;
 wire  [7:0] uart2_readdata;
+wire  [7:0] uart3_readdata;
+wire        uart3_irq;
+wire        uart3_rts_n;
+wire        uart3_dtr_n;
+wire        uart3_rx;
 wire  [7:0] mpu_readdata;
 wire  [7:0] dma_io_readdata;
 wire  [7:0] pic_readdata;
@@ -343,6 +355,7 @@ always @(posedge clk_sys) begin
 	sb_cs         <= ({iobus_address[15:4], 4'd0} == 16'h0220);
 	uart1_cs      <= ({iobus_address[15:3], 3'd0} == 16'h03F8);
 	uart2_cs      <= ({iobus_address[15:3], 3'd0} == 16'h02F8);
+	uart3_cs      <= ({iobus_address[15:3], 3'd0} == 16'h03E8);  // COM3
 	mpu_cs        <= ({iobus_address[15:1], 1'd0} == 16'h0330);
 	vga_b_cs      <= ({iobus_address[15:4], 4'd0} == 16'h03B0);
 	vga_c_cs      <= ({iobus_address[15:4], 4'd0} == 16'h03C0);
@@ -379,6 +392,7 @@ wire [7:0] iobus_readdata8 =
 	( sb_cs|fm_cs                            ) ? sound_readdata    :
 	( uart1_cs                               ) ? uart1_readdata    :
 	( uart2_cs                               ) ? uart2_readdata    :
+	( uart3_cs                               ) ? uart3_readdata    :
 	( mpu_cs                                 ) ? mpu_readdata      :
 	( vga_b_cs|vga_c_cs|vga_d_cs             ) ? vga_io_readdata   :
 	( joy_cs                                 ) ? joystick_readdata :
@@ -743,6 +757,49 @@ uart uart2
 	.irq               (irq_3)
 );
 
+// COM3 (0x3E8). Shares IRQ4 with the otherwise-idle COM1 so a stock DOS
+// serial-mouse driver (CuteMouse CTMOUSE /S3) detects it without a
+// non-standard IRQ. Its RX is fed by the serial_mouse generator.
+uart uart3
+(
+	.clk               (clk_sys),
+	.br_clk            (clk_uart2),    // standard 1.8432 MHz baud reference
+	.reset             (reset),
+
+	.address           (iobus_address[2:0]),
+	.writedata         (iobus_writedata[7:0]),
+	.read              (iobus_read),
+	.write             (iobus_write),
+	.readdata          (uart3_readdata),
+	.cs                (uart3_cs),
+
+	.rx                (uart3_rx),
+	.tx                (),
+	.cts_n             (0),
+	.dcd_n             (0),
+	.dsr_n             (0),
+	.rts_n             (uart3_rts_n),
+	.dtr_n             (uart3_dtr_n),
+	.ri_n              (1),
+
+	.irq               (uart3_irq)
+);
+
+// Generates the 1200-baud 7N1 Microsoft serial-mouse waveform into UART3 RX
+// from the 2nd-mouse deltas delivered over hps_io UIO 0x07.
+serial_mouse #(.CLKS_PER_BIT(75000)) serial_mouse  // 90 MHz / 1200 baud
+(
+	.clk     (clk_sys),
+	.reset   (reset),
+	.rts     (~uart3_rts_n),
+	.dtr     (~uart3_dtr_n),
+	.dx      (mouse2_dx),
+	.dy      (mouse2_dy),
+	.btn     (mouse2_btn),
+	.strobe  (mouse2_stb),
+	.rx      (uart3_rx)
+);
+
 mpu mpu
 (
 	.clk               (clk_sys),
@@ -837,7 +894,7 @@ always @* begin
 	interrupt[0]  = irq_0;
 	interrupt[1]  = irq_1;
 	interrupt[3]  = irq_3;
-	interrupt[4]  = irq_4;
+	interrupt[4]  = irq_4 | uart3_irq;   // COM1 + COM3 (serial mouse)
 	interrupt[5]  = irq_5;
 	interrupt[6]  = irq_6;
 	interrupt[7]  = irq_7;

--- a/rtl/system.v
+++ b/rtl/system.v
@@ -60,11 +60,13 @@ module system
 	output        uart2_rts_n,
 	output        uart2_dtr_n,
 
-	// 2nd mouse (delivered over hps_io UIO 0x07) -> COM3 serial-mouse generator
+	// 2nd mouse (delivered over hps_io UIO 0x07) -> serial-mouse generator,
+	// routed to the COM port selected by mouse2_com (0=Off 1..4=COM1..COM4).
 	input   [7:0] mouse2_dx,
 	input   [7:0] mouse2_dy,
 	input   [2:0] mouse2_btn,
 	input         mouse2_stb,
+	input   [2:0] mouse2_com,
 
 	input         clk_mpu,
 	input         mpu_rx,
@@ -203,6 +205,7 @@ reg         sb_cs;
 reg         uart1_cs;
 reg         uart2_cs;
 reg         uart3_cs;
+reg         uart4_cs;
 reg         mpu_cs;
 reg         vga_b_cs;
 reg         vga_c_cs;
@@ -225,7 +228,50 @@ wire  [7:0] uart3_readdata;
 wire        uart3_irq;
 wire        uart3_rts_n;
 wire        uart3_dtr_n;
-wire        uart3_rx;
+wire  [7:0] uart4_readdata;
+wire        uart4_irq;
+wire        uart4_rts_n;
+wire        uart4_dtr_n;
+// --- 2nd-mouse COM-port selection, debounced -------------------------------
+// The OSD option updates status live as it is browsed; routing the mouse onto
+// COM1/COM2 even momentarily could disturb MIDI / user-port traffic. So only
+// APPLY a selection after it has been stable ~0.5s (on the fixed clk_uart2,
+// ~1.8432MHz). Scrolling THROUGH ports never settles, so it never takes effect.
+reg  [2:0] mouse2_com_m, mouse2_com_s;   // 2-FF sync clk_sys -> clk_uart2
+reg  [2:0] mouse2_com_app = 3'd0;        // the applied (routed) selection
+reg [19:0] mouse2_com_cnt = 0;           // stability counter (~0.57s @ 1.8432MHz)
+always @(posedge clk_uart2) begin
+	mouse2_com_m <= mouse2_com;
+	mouse2_com_s <= mouse2_com_m;
+	if (reset) begin
+		mouse2_com_app <= 3'd0;
+		mouse2_com_cnt <= 0;
+	end
+	else if (mouse2_com_s != mouse2_com_app) begin
+		if (&mouse2_com_cnt) mouse2_com_app <= mouse2_com_s; // stable long enough
+		else                 mouse2_com_cnt <= mouse2_com_cnt + 1'b1;
+	end
+	else mouse2_com_cnt <= 0;             // already applied: hold counter cleared
+end
+
+// Serial-mouse waveform + per-UART effective RX (mouse routed to the selected COM)
+wire        mouse_wave;
+wire        uart1_rx_eff  = (mouse2_com_app == 3'd1) ? mouse_wave : uart1_rx;
+wire        uart2_rx_eff  = (mouse2_com_app == 3'd2) ? mouse_wave : uart2_rx;
+wire        uart3_rx_eff  = (mouse2_com_app == 3'd3) ? mouse_wave : 1'b1;
+wire        uart4_rx_eff  = (mouse2_com_app == 3'd4) ? mouse_wave : 1'b1;
+// serial_mouse watches the selected port's RTS/DTR (active-low -> invert at use)
+reg         sm_rts_n;
+reg         sm_dtr_n;
+always @(*) begin
+	case (mouse2_com_app)
+		3'd1: begin sm_rts_n = uart1_rts_n; sm_dtr_n = uart1_dtr_n; end
+		3'd2: begin sm_rts_n = uart2_rts_n; sm_dtr_n = uart2_dtr_n; end
+		3'd3: begin sm_rts_n = uart3_rts_n; sm_dtr_n = uart3_dtr_n; end
+		3'd4: begin sm_rts_n = uart4_rts_n; sm_dtr_n = uart4_dtr_n; end
+		default: begin sm_rts_n = 1'b1; sm_dtr_n = 1'b1; end // Off: deasserted
+	endcase
+end
 wire  [7:0] mpu_readdata;
 wire  [7:0] dma_io_readdata;
 wire  [7:0] pic_readdata;
@@ -356,6 +402,7 @@ always @(posedge clk_sys) begin
 	uart1_cs      <= ({iobus_address[15:3], 3'd0} == 16'h03F8);
 	uart2_cs      <= ({iobus_address[15:3], 3'd0} == 16'h02F8);
 	uart3_cs      <= ({iobus_address[15:3], 3'd0} == 16'h03E8);  // COM3
+	uart4_cs      <= ({iobus_address[15:3], 3'd0} == 16'h02E8);  // COM4
 	mpu_cs        <= ({iobus_address[15:1], 1'd0} == 16'h0330);
 	vga_b_cs      <= ({iobus_address[15:4], 4'd0} == 16'h03B0);
 	vga_c_cs      <= ({iobus_address[15:4], 4'd0} == 16'h03C0);
@@ -393,6 +440,7 @@ wire [7:0] iobus_readdata8 =
 	( uart1_cs                               ) ? uart1_readdata    :
 	( uart2_cs                               ) ? uart2_readdata    :
 	( uart3_cs                               ) ? uart3_readdata    :
+	( uart4_cs                               ) ? uart4_readdata    :
 	( mpu_cs                                 ) ? mpu_readdata      :
 	( vga_b_cs|vga_c_cs|vga_d_cs             ) ? vga_io_readdata   :
 	( joy_cs                                 ) ? joystick_readdata :
@@ -720,7 +768,7 @@ uart uart1
 	.readdata          (uart1_readdata),
 	.cs                (uart1_cs),
 
-	.rx                (uart1_rx),
+	.rx                (uart1_rx_eff),
 	.tx                (uart1_tx),
 	.cts_n             (uart1_cts_n),
 	.dcd_n             (uart1_dcd_n),
@@ -745,7 +793,7 @@ uart uart2
 	.readdata          (uart2_readdata),
 	.cs                (uart2_cs),
 
-	.rx                (uart2_rx),
+	.rx                (uart2_rx_eff),
 	.tx                (uart2_tx),
 	.cts_n             (uart2_cts_n),
 	.dcd_n             (uart2_dcd_n),
@@ -757,9 +805,11 @@ uart uart2
 	.irq               (irq_3)
 );
 
-// COM3 (0x3E8). Shares IRQ4 with the otherwise-idle COM1 so a stock DOS
-// serial-mouse driver (CuteMouse CTMOUSE /S3) detects it without a
-// non-standard IRQ. Its RX is fed by the serial_mouse generator.
+// COM3 (0x3E8, IRQ4) and COM4 (0x2E8, IRQ3) are the two "extra" UARTs added for
+// the 2nd mouse. Either can host the serial-mouse waveform (selected via the OSD
+// "2nd Mouse Port"); when not selected their RX idles high. COM3/COM1 share IRQ4
+// and COM4/COM2 share IRQ3 — the standard PC COM IRQ map, which the games' own
+// "Microsoft Mouse, COMx, IRQy" option already expects.
 uart uart3
 (
 	.clk               (clk_sys),
@@ -773,7 +823,7 @@ uart uart3
 	.readdata          (uart3_readdata),
 	.cs                (uart3_cs),
 
-	.rx                (uart3_rx),
+	.rx                (uart3_rx_eff),
 	.tx                (),
 	.cts_n             (0),
 	.dcd_n             (0),
@@ -785,13 +835,40 @@ uart uart3
 	.irq               (uart3_irq)
 );
 
-// Generates the 1200-baud 7N1 Microsoft serial-mouse waveform into UART3 RX
-// from the 2nd-mouse deltas delivered over hps_io UIO 0x07.
+uart uart4
+(
+	.clk               (clk_sys),
+	.br_clk            (clk_uart2),    // standard 1.8432 MHz baud reference
+	.reset             (reset),
+
+	.address           (iobus_address[2:0]),
+	.writedata         (iobus_writedata[7:0]),
+	.read              (iobus_read),
+	.write             (iobus_write),
+	.readdata          (uart4_readdata),
+	.cs                (uart4_cs),
+
+	.rx                (uart4_rx_eff),
+	.tx                (),
+	.cts_n             (0),
+	.dcd_n             (0),
+	.dsr_n             (0),
+	.rts_n             (uart4_rts_n),
+	.dtr_n             (uart4_dtr_n),
+	.ri_n              (1),
+
+	.irq               (uart4_irq)
+);
+
+// Generates the 1200-baud 7N1 Microsoft serial-mouse waveform from the 2nd-mouse
+// deltas delivered over hps_io UIO 0x07. Its output (mouse_wave) is muxed onto
+// the RX of whichever COM port the OSD selects; it watches that same port's
+// RTS/DTR (sm_rts_n/sm_dtr_n) so the driver's detect handshake works on any port.
 //
 // IMPORTANT: clock this from clk_uart2 (the *fixed* 1.8432 MHz UART baud
 // reference), NOT clk_sys. clk_sys is reconfigured at runtime by the ao486
 // CPU-speed selector (15..100 MHz), which would shift the generated baud and
-// break the framing. UART3 receives one bit every 16*divisor br_clk cycles
+// break the framing. The UART receives one bit every 16*divisor br_clk cycles
 // (divisor=96 for the DOS-standard 1200 baud), so holding each generated bit
 // for exactly 16*96 = 1536 clk_uart2 cycles makes the generator bit-period
 // identical to the UART's sampling window on the very same clock.
@@ -799,13 +876,13 @@ serial_mouse #(.CLKS_PER_BIT(1536)) serial_mouse  // 16 * divisor(96) @ clk_uart
 (
 	.clk     (clk_uart2),
 	.reset   (reset),
-	.rts     (~uart3_rts_n),
-	.dtr     (~uart3_dtr_n),
+	.rts     (~sm_rts_n),
+	.dtr     (~sm_dtr_n),
 	.dx      (mouse2_dx),
 	.dy      (mouse2_dy),
 	.btn     (mouse2_btn),
 	.strobe  (mouse2_stb),
-	.rx      (uart3_rx)
+	.rx      (mouse_wave)
 );
 
 mpu mpu
@@ -901,7 +978,7 @@ always @* begin
 
 	interrupt[0]  = irq_0;
 	interrupt[1]  = irq_1;
-	interrupt[3]  = irq_3;
+	interrupt[3]  = irq_3 | uart4_irq;   // COM2 + COM4 (serial mouse)
 	interrupt[4]  = irq_4 | uart3_irq;   // COM1 + COM3 (serial mouse)
 	interrupt[5]  = irq_5;
 	interrupt[6]  = irq_6;

--- a/rtl/system.v
+++ b/rtl/system.v
@@ -787,9 +787,17 @@ uart uart3
 
 // Generates the 1200-baud 7N1 Microsoft serial-mouse waveform into UART3 RX
 // from the 2nd-mouse deltas delivered over hps_io UIO 0x07.
-serial_mouse #(.CLKS_PER_BIT(75000)) serial_mouse  // 90 MHz / 1200 baud
+//
+// IMPORTANT: clock this from clk_uart2 (the *fixed* 1.8432 MHz UART baud
+// reference), NOT clk_sys. clk_sys is reconfigured at runtime by the ao486
+// CPU-speed selector (15..100 MHz), which would shift the generated baud and
+// break the framing. UART3 receives one bit every 16*divisor br_clk cycles
+// (divisor=96 for the DOS-standard 1200 baud), so holding each generated bit
+// for exactly 16*96 = 1536 clk_uart2 cycles makes the generator bit-period
+// identical to the UART's sampling window on the very same clock.
+serial_mouse #(.CLKS_PER_BIT(1536)) serial_mouse  // 16 * divisor(96) @ clk_uart2 = 1200 baud
 (
-	.clk     (clk_sys),
+	.clk     (clk_uart2),
 	.reset   (reset),
 	.rts     (~uart3_rts_n),
 	.dtr     (~uart3_dtr_n),

--- a/sys/hps_io.sv
+++ b/sys/hps_io.sv
@@ -106,6 +106,12 @@ module hps_io #(parameter CONF_STR, CONF_STR_BRAM=0, PS2DIV=0, WIDE=0, VDNUM=1, 
 	output reg [24:0] ps2_mouse = 0,
 	output reg [15:0] ps2_mouse_ext = 0, // 15:8 - reserved(additional buttons), 7:0 - wheel movements
 
+	// 2nd mouse (UIO cmd 0x07): signed deltas + buttons, strobe toggles per update
+	output reg  [7:0] mouse2_dx = 0,
+	output reg  [7:0] mouse2_dy = 0,
+	output reg  [7:0] mouse2_btn = 0,
+	output reg        mouse2_stb = 0,
+
 	output      [1:0] buttons,
 	output            forced_scandoubler,
 	output            direct_video,
@@ -302,6 +308,7 @@ always@(posedge clk_sys) begin : uio_block
 
 	if(~io_enable) begin
 		if(cmd == 4 && !ps2skip) ps2_mouse[24] <= ~ps2_mouse[24];
+			if(cmd == 7) mouse2_stb <= ~mouse2_stb;   // 2nd mouse update complete
 		if(cmd == 5 && !ps2skip) begin
 			ps2_key <= {~ps2_key[10], pressed, extended, ps2_key_raw[7:0]};
 			if(ps2_key_raw == 'hE012E07C) ps2_key[9:0] <= 'h37C; // prnscr pressed
@@ -349,6 +356,10 @@ always@(posedge clk_sys) begin : uio_block
 			casex(cmd)
 				// buttons and switches
 				'h01: cfg <= io_din;
+				// 2nd mouse: byte1=dx, byte2=dy (signed 8-bit), byte3=buttons
+				'h07: if(byte_cnt==1) mouse2_dx <= io_din[7:0];
+				      else if(byte_cnt==2) mouse2_dy <= io_din[7:0];
+				      else if(byte_cnt==3) mouse2_btn <= io_din[7:0];
 				'h02: if(byte_cnt==1) joystick_0[15:0] <= io_din; else joystick_0[31:16] <= io_din;
 				'h03: if(byte_cnt==1) joystick_1[15:0] <= io_din; else joystick_1[31:16] <= io_din;
 				'h10: if(byte_cnt==1) joystick_2[15:0] <= io_din; else joystick_2[31:16] <= io_din;


### PR DESCRIPTION
This feature relies on this pull request to be added to MiSTer Main:
https://github.com/MiSTer-devel/Main_MiSTer/pull/1220

This adds support for a second mouse for games like The Settlers and Settlers 2 Gold. It does this by adding an option for the second mouse in the hardware settings, letting you have it disabled, or use COM1-4. The games will need com 1 or 2 and its probably best to use COM2 because COM1 can be used for other features.