### PR TITLE
L1 Cache: Fix prefetch FIFO coherency issue with non-identity paging

### DIFF
--- a/rtl/ao486/memory/icache.v
+++ b/rtl/ao486/memory/icache.v
@@ -31,7 +31,7 @@ module icache(
     input           rst_n,
     
     input           cache_disable,
-
+    
     //RESP:
     input           pr_reset,
     
@@ -64,7 +64,10 @@ module icache(
     output [4:0]        prefetched_length,
     //END
     
-    input   [27:2]      snoop_addr,
+    input   [31:0]      snoop_linear_addr, // linear address
+    input               snoop_linear_we,
+    
+    input   [27:2]      snoop_addr, // word aligned physical address
     input   [31:0]      snoop_data,
     input    [3:0]      snoop_be,
     input               snoop_we
@@ -79,7 +82,7 @@ reg          state;
 reg [4:0]    length;
 reg [11:0]   partial_length;
 reg          reset_waiting;
-             
+
 wire [4:0]   partial_length_current;
 
 wire [11:0]  length_burst;
@@ -96,29 +99,28 @@ reg  [31:0]  min_check;
 reg  [31:0]  max_check;
 reg   [1:0]  reset_prefetch_count = 2'd0;
 
-
 //------------------------------------------------------------------------------
 
 wire reset_combined = reset_prefetch | pr_reset;
 
 always @(posedge clk) begin
-   prefetch_checknext <= 1'b0;
-   prefetch_checkaddr <= { 4'd0, snoop_addr, 2'd0 };
-   min_check          <= delivered_eip;
-   max_check          <= prefetch_address + 5'd20; // cache read burst is 16 bytes, so we need to look a bit further, additional + 4 because of 1 cycle delay.
-   
-   if (snoop_we) prefetch_checknext <= 1'b1;
-   
-   if (prefetch_checknext && prefetch_checkaddr >= min_check && prefetch_checkaddr <= max_check) begin
-      reset_prefetch       <= 1'b1;
-      reset_prefetch_count <= 2'd2;
-   end
-   
-   if (reset_prefetch_count > 2'd0) begin
-      reset_prefetch_count <= reset_prefetch_count - 1'd1;
-      if (reset_prefetch_count == 2'd1) reset_prefetch <= 1'd0;
-   end
-   
+    prefetch_checknext <= 1'b0;
+    prefetch_checkaddr <= snoop_linear_addr;
+    min_check          <= delivered_eip;
+    max_check          <= prefetch_address + 5'd20; // cache read burst is 16 bytes, so we need to look a bit further, additional + 4 because of 1 cycle delay.
+    
+    if (snoop_linear_we) prefetch_checknext <= 1'b1;
+    
+    if (reset_prefetch_count > 2'd0) begin
+        reset_prefetch_count <= reset_prefetch_count - 1'd1;
+        if (reset_prefetch_count == 2'd1) reset_prefetch <= 1'd0;
+    end
+    
+    // Reset the prefetch fifo when a write hits it (checks are done in linear address space)
+    if (prefetch_checknext && prefetch_checkaddr >= min_check && prefetch_checkaddr <= max_check) begin
+        reset_prefetch       <= 1'b1;
+        reset_prefetch_count <= 2'd2;
+    end
 end
 
 //------------------------------------------------------------------------------
@@ -126,7 +128,7 @@ end
 //MIN(partial_length, length_saved)
 assign partial_length_current =
     ({ 2'b0, partial_length[2:0] } > length)? length : { 2'b0, partial_length[2:0] };
-    
+
 //------------------------------------------------------------------------------
 
 always @(posedge clk) begin
@@ -142,7 +144,7 @@ assign length_burst =
     (icacheread_address[1:0] == 2'd1)? { 3'd4, 3'd4, 3'd4, 3'd3 } :
     (icacheread_address[1:0] == 2'd2)? { 3'd4, 3'd4, 3'd4, 3'd2 } :
                                        { 3'd4, 3'd4, 3'd4, 3'd1 };
-                            
+
 assign prefetchfifo_write_data =
     (partial_length[2:0] == 3'd1)?   {                  4'd1 ,              24'd0, readcode_cache_data[31:24] } :
     (partial_length[2:0] == 3'd2)?   { (length > 5'd2)? 4'd2 : length[3:0], 16'd0, readcode_cache_data[31:16] } :
@@ -152,13 +154,13 @@ assign prefetchfifo_write_data =
 //------------------------------------------------------------------------------
 
 l1_icache l1_icache_inst(
-   
+    
     .CLK             (clk),
     .RESET           (~rst_n),
     .pr_reset        (reset_combined),
-	 
+    
     .DISABLE         (cache_disable),
-
+    
     .CPU_REQ         (readcode_cache_do),
     .CPU_ADDR        (readcode_cache_address),
     .CPU_VALID       (readcode_cache_valid),
@@ -177,48 +179,48 @@ l1_icache l1_icache_inst(
 );
 
 assign readcode_cache_do =
-   (~rst_n) ? (`FALSE) :
-   (state == STATE_IDLE && ~(reset_combined) && icacheread_do && icacheread_length > 5'd0) ? (`TRUE) :
-   `FALSE;
-   
+    (~rst_n) ? (`FALSE) :
+    (state == STATE_IDLE && ~(reset_combined) && icacheread_do && icacheread_length > 5'd0) ? (`TRUE) :
+    `FALSE;
+
 assign readcode_cache_address = { icacheread_address[31:2], 2'd0 };
-   
+
 assign prefetchfifo_write_do =
-   (~rst_n) ? (`FALSE) :
-   (state == STATE_READ && reset_combined == `FALSE && reset_waiting == `FALSE && readcode_cache_valid) ? (`TRUE) :
-   `FALSE;
-   
-assign prefetched_length       = partial_length_current;
+    (~rst_n) ? (`FALSE) :
+    (state == STATE_READ && reset_combined == `FALSE && reset_waiting == `FALSE && readcode_cache_valid) ? (`TRUE) :
+    `FALSE;
+
+assign prefetched_length = partial_length_current;
 
 assign prefetched_do =
-   (~rst_n) ? (`FALSE) :
-   (state == STATE_READ && reset_combined == `FALSE && reset_waiting == `FALSE && readcode_cache_valid) ? (`TRUE) :
-   `FALSE;
-   
+    (~rst_n) ? (`FALSE) :
+    (state == STATE_READ && reset_combined == `FALSE && reset_waiting == `FALSE && readcode_cache_valid) ? (`TRUE) :
+    `FALSE;
+
 always @(posedge clk) begin
-   if(rst_n == 1'b0) begin
-      state          <= STATE_IDLE;
-      length         <= 5'b0;
-      partial_length <= 12'b0;
-   end
-   else begin
-      if(state == STATE_IDLE && ~(reset_combined) && icacheread_do && icacheread_length > 5'd0) begin
-         state          <= STATE_READ;
-         partial_length <= length_burst;
-         length         <= icacheread_length;
-      end
-      else if (state == STATE_READ) begin
-         if(reset_combined == `FALSE && reset_waiting == `FALSE) begin
-            if(readcode_cache_valid) begin
-               if(partial_length[2:0] > 3'd0 && length > 5'd0) begin
-                  length         <= length - partial_length_current;
-                  partial_length <= { 3'd0, partial_length[11:3] }; 
-               end
+    if(rst_n == 1'b0) begin
+        state          <= STATE_IDLE;
+        length         <= 5'b0;
+        partial_length <= 12'b0;
+    end
+    else begin
+        if(state == STATE_IDLE && ~(reset_combined) && icacheread_do && icacheread_length > 5'd0) begin
+            state          <= STATE_READ;
+            partial_length <= length_burst;
+            length         <= icacheread_length;
+        end
+        else if (state == STATE_READ) begin
+            if(reset_combined == `FALSE && reset_waiting == `FALSE) begin
+                if(readcode_cache_valid) begin
+                    if(partial_length[2:0] > 3'd0 && length > 5'd0) begin
+                        length         <= length - partial_length_current;
+                        partial_length <= { 3'd0, partial_length[11:3] };
+                    end
+                end
             end
-         end
-         if(readcode_cache_done) state <= STATE_IDLE;
-      end
-   end
-end     
+            if(readcode_cache_done) state <= STATE_IDLE;
+        end
+    end
+end
 
 endmodule

--- a/rtl/ao486/memory/memory.v
+++ b/rtl/ao486/memory/memory.v
@@ -364,10 +364,10 @@ avalon_mem avalon_mem_inst(
     .readcode_partial           (req_readcode_partial),        //output [31:0]
     //END
     
-    .snoop_addr                 (snoop_addr),
-    .snoop_data                 (snoop_data),
-    .snoop_be                   (snoop_be),  
-    .snoop_we                   (snoop_we),
+    .snoop_addr                 (snoop_addr),                   //output [27:2] (word aligned physical address)
+    .snoop_data                 (snoop_data),                   //output [31:0]
+    .snoop_be                   (snoop_be),                     //output [3:0]
+    .snoop_we                   (snoop_we),                     //output
     
     // avalon master
     .avm_address                (avm_address),                  //output [31:0]
@@ -433,10 +433,13 @@ icache icache_inst(
     .prefetched_length          (prefetched_length),          //output [4:0]
     //END
     
-    .snoop_addr                 (snoop_addr),
-    .snoop_data                 (snoop_data),
-    .snoop_be                   (snoop_be),  
-    .snoop_we                   (snoop_we)
+    .snoop_linear_addr          (write_address),              //input [31:0] (linear address)
+    .snoop_linear_we            (write_do && !write_done),    //input
+    
+    .snoop_addr                 (snoop_addr),                 //input [27:2] (word aligned physical address)
+    .snoop_data                 (snoop_data),                 //input [31:0]
+    .snoop_be                   (snoop_be),                   //input [3:0]
+    .snoop_we                   (snoop_we)                    //input
 );
 
 assign invdcode_done = 1'b1;


### PR DESCRIPTION
When non-identity paging was enabled, writes hitting the prefetch FIFO were not detected and therefore did not trigger a prefetch reset.

The prefetch FIFO write-hit check incorrectly compared a physical address with the prefetch FIFO's linear address range. This comparison only worked when paging was disabled or identity paging was used.

Using a linear address for this check fixes the issue and prevents self-modifying code from leaving stale instructions in the prefetch FIFO.

Fixes: #224